### PR TITLE
Enable release automation for flytectl

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        COMPONENT: [flyteadmin, flytepropeller, flyteconsole, flytecopilot, flyteplugins, datacatalog]
+        COMPONENT: [flyteadmin, flytepropeller, flyteconsole, flytecopilot, flyteplugins, datacatalog, flytectl]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# TL;DR
Enable release automation for flytectl. It will create a pr in flytectl with latest flyteidl version. Created a [pr](https://github.com/flyteorg/flytectl/pull/51/files#diff-c13297ca847f2010a720cbe01f87ffc1ae4e0edbb41c8981a93d97f6a1265b75R1) for flytectl changes 
