### PR TITLE
nit: use .rst links in readme & typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@
 Flyte IDL
 ================
 This is one of the core repositories of Flyte and contains the Specification of
-the Flyte Lanugage. The Specification is maintained using Googles fantastic
-Protcol buffers library. The code and docs are auto-generated.
+the Flyte Language. The Specification is maintained using Google's fantastic
+Protocol buffers library. The code and docs are auto-generated.
 
-* [flyte.org](https://flyte.org)
-* [Flyte Docs](http://flyte.readthedocs.org/)
-* [FlyteIDL Docs](http://flyteidl.readthedocs.org)
+* `flyte.org <https://flyte.org>`_
+* `Flyte Docs <http://flyte.readthedocs.org/>`_
+* `FlyteIDL Docs <http://flyteidl.readthedocs.org>`_
 
 Generate Code from protobuf
 ----------------------------


### PR DESCRIPTION
# TL;DR

looks like the readme is in RST, but using markdown links `[bla](foo.com)`. Switched to use .rst links `bla <foo.com>_`, and fixed a couple typos.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
Docs change 
## Are all requirements met?
N/A
 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
N/A
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
