### PR TITLE
Added support for Generic type for extracting a literal value

### DIFF
--- a/clients/go/coreutils/extract_literal.go
+++ b/clients/go/coreutils/extract_literal.go
@@ -56,6 +56,8 @@ func ExtractFromLiteral(literal *core.Literal) (interface{}, error) {
 			}
 		case *core.Scalar_Blob:
 			return scalarValue.Blob.Uri, nil
+		case *core.Scalar_Generic:
+			return scalarValue.Generic, nil
 		default:
 			return nil, fmt.Errorf("unsupported literal scalar type %T", scalarValue)
 		}

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -106,7 +106,10 @@ func TestFetchLiteral(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
-		literalVal := "{\"x\": 1, \"y\":\"ystringvalue\"}"
+		literalVal := map[string]interface{}{
+			"x": 1,
+			"y": "ystringvalue",
+		}
 		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}
 		lit, err := MakeLiteralForType(literalType, literalVal)
 		assert.NoError(t, err)

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -132,4 +132,29 @@ func TestFetchLiteral(t *testing.T) {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
 	})
+
+	t.Run("Generic Passed As String", func(t *testing.T) {
+		literalVal := "{\"x\": 1,\"y\": \"ystringvalue\"}"
+		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}
+		lit, err := MakeLiteralForType(literalType, literalVal)
+		assert.NoError(t, err)
+		extractedLiteralVal, err := ExtractFromLiteral(lit)
+		assert.NoError(t, err)
+		fieldsMap := map[string]*structpb.Value{
+			"x": {
+				Kind: &structpb.Value_NumberValue{NumberValue: 1},
+			},
+			"y": {
+				Kind: &structpb.Value_StringValue{StringValue: "ystringvalue"},
+			},
+		}
+		expectedStructVal := &structpb.Struct{
+			Fields: fieldsMap,
+		}
+		extractedStructValue := extractedLiteralVal.(*structpb.Struct)
+		assert.Equal(t, len(expectedStructVal.Fields), len(extractedStructValue.Fields))
+		for key, val := range expectedStructVal.Fields {
+			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
+		}
+	})
 }

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -6,6 +6,9 @@ package coreutils
 import (
 	"testing"
 
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,5 +103,30 @@ func TestFetchLiteral(t *testing.T) {
 		assert.NotNil(t, p.GetScalar())
 		_, err = ExtractFromLiteral(p)
 		assert.NotNil(t, err)
+	})
+
+	t.Run("Generic", func(t *testing.T) {
+		literalVal := "{\"x\": 1, \"y\":\"ystringvalue\"}"
+		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}
+		lit, err := MakeLiteralForType(literalType, literalVal)
+		assert.NoError(t, err)
+		extractedLiteralVal, err := ExtractFromLiteral(lit)
+		assert.NoError(t, err)
+		fieldsMap := map[string]*structpb.Value{
+			"x": {
+				Kind: &structpb.Value_NumberValue{NumberValue: 1},
+			},
+			"y": {
+				Kind: &structpb.Value_StringValue{StringValue: "ystringvalue"},
+			},
+		}
+		expectedStructVal := &structpb.Struct{
+			Fields: fieldsMap,
+		}
+		extractedStructValue := extractedLiteralVal.(*structpb.Struct)
+		assert.Equal(t, len(expectedStructVal.Fields), len(extractedStructValue.Fields))
+		for key, val := range expectedStructVal.Fields {
+			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
+		}
 	})
 }

--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -2,6 +2,7 @@
 package coreutils
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -11,9 +12,9 @@ import (
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/storage"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
-	gateway "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 )
 
@@ -350,10 +351,7 @@ func MakeLiteralForSimpleType(t core.SimpleType, s string) (*core.Literal, error
 	switch t {
 	case core.SimpleType_STRUCT:
 		st := &structpb.Struct{}
-		// Using grpc gateway probobuf unmarshaller which allows unmarshalling non-proto fields.
-		// https://github.com/grpc-ecosystem/grpc-gateway/blob/9f29462311efebda32dfbba90afe20c05e88fe52/runtime/marshal_jsonpb.go#L186
-		jsonUnMarshaller := gateway.JSONPb{}
-		err := jsonUnMarshaller.Unmarshal([]byte(s), st)
+		err := jsonpb.UnmarshalString(s, st)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load generic type as json.")
 		}
@@ -489,10 +487,7 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		strValue := fmt.Sprintf("%v", v)
 		if newT.Simple == core.SimpleType_STRUCT {
 			if _, isValueStringType := v.(string); !isValueStringType {
-				// Using grpc gateway probobuf marshaller which allows marshalling non-proto fields.
-				// https://github.com/grpc-ecosystem/grpc-gateway/blob/9f29462311efebda32dfbba90afe20c05e88fe52/runtime/marshal_jsonpb.go#L33
-				jsonMarshaller := gateway.JSONPb{}
-				byteValue, err := jsonMarshaller.Marshal(v)
+				byteValue, err := json.Marshal(v)
 				if err != nil {
 					return nil, fmt.Errorf("unable to marshal to yaml string for struct value %v", v)
 				}

--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -489,7 +489,7 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 			if _, isValueStringType := v.(string); !isValueStringType {
 				byteValue, err := json.Marshal(v)
 				if err != nil {
-					return nil, fmt.Errorf("unable to marshal to yaml string for struct value %v", v)
+					return nil, fmt.Errorf("unable to marshal to json string for struct value %v", v)
 				}
 				strValue = string(byteValue)
 			}


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Inorder to support generic types, they must be passed in map[string]interface.
This change is required to support generic values to be passed from flytectl eg : DataClass.

Tested example  : 
```
@task
def add(x: Datum, y: Datum) -> Datum:
    """
    Flytekit will automatically convert the passed in json into a DataClass. If the structures dont match, it will raise
    a runtime failure
    """
    x.z.update(y.z)
    return Datum(x=x.x + y.x, y=x.y + y.y, z=x.z)
```

Input to flytectl config:
```
iamRoleARN: "<iamrole>"
inputs:
  "x":
    "x": 2
    "y": ydatafory
    "z":
      1 : "foo"
      2 : "bar"
  "y":
    "x": 3
    "y": ydataforx
    "z":
      3 : "buzz"
      4 : "lightyear"
kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
task: core.type_system.custom_objects.add
version: v3

```


## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1055

## Follow-up issue
_NA_
