### PR TITLE
Handling large integers

### DIFF
--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -4,6 +4,7 @@ package coreutils
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -492,7 +493,9 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		if v == nil {
 			strValue = ""
 		}
-
+		if f, ok := v.(float64); ok && math.Trunc(f) == f {
+			strValue = fmt.Sprintf("%.0f", math.Trunc(f))
+		}
 		if newT.Simple == core.SimpleType_STRUCT {
 			if _, isValueStringType := v.(string); !isValueStringType {
 				byteValue, err := json.Marshal(v)

--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -493,6 +493,10 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		if v == nil {
 			strValue = ""
 		}
+		// Note this is to support large integers which by default when passed from an unmarshalled json will be
+		// converted to float64 and printed as exponential format by Sprintf.
+		// eg : 8888888 get converted to 8.888888e+06 and which causes strconv.ParseInt to fail
+		// Inorder to avoid this we explicitly add this check.
 		if f, ok := v.(float64); ok && math.Trunc(f) == f {
 			strValue = fmt.Sprintf("%.0f", math.Trunc(f))
 		}

--- a/clients/go/coreutils/literals_test.go
+++ b/clients/go/coreutils/literals_test.go
@@ -396,7 +396,7 @@ func TestMakeLiteralForType(t *testing.T) {
 	t.Run("IntegerComingInAsFloatOverFlow", func(t *testing.T) {
 		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}
 		_, err := MakeLiteralForType(literalType, 8.888888e+19)
-		//assert.Nil(t, err)
+		assert.NotNil(t, err)
 		var numError error
 		numError = &strconv.NumError{
 			Func: "ParseInt",

--- a/clients/go/coreutils/literals_test.go
+++ b/clients/go/coreutils/literals_test.go
@@ -6,6 +6,7 @@ package coreutils
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -386,6 +388,31 @@ func TestMakeLiteralForType(t *testing.T) {
 		assert.NoError(t, err)
 		literalVal := &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{
 			Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 1}}}}}}
+		expectedVal, _ := ExtractFromLiteral(literalVal)
+		actualVal, _ := ExtractFromLiteral(val)
+		assert.Equal(t, expectedVal, actualVal)
+	})
+
+	t.Run("IntegerComingInAsFloatOverFlow", func(t *testing.T) {
+		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}
+		_, err := MakeLiteralForType(literalType, 8.888888e+19)
+		//assert.Nil(t, err)
+		var numError error
+		numError = &strconv.NumError{
+			Func: "ParseInt",
+			Num:  "88888880000000000000",
+			Err:  fmt.Errorf("value out of range"),
+		}
+		parseIntError := errors.WithMessage(numError, "failed to parse integer value")
+		assert.Equal(t, errors.WithStack(parseIntError).Error(), err.Error())
+	})
+
+	t.Run("IntegerComingInAsFloat", func(t *testing.T) {
+		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}
+		val, err := MakeLiteralForType(literalType, 8.888888e+18)
+		assert.NoError(t, err)
+		literalVal := &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_Primitive{Primitive: &core.Primitive{Value: &core.Primitive_Integer{Integer: 8.888888e+18}}}}}}
 		expectedVal, _ := ExtractFromLiteral(literalVal)
 		actualVal, _ := ExtractFromLiteral(val)
 		assert.Equal(t, expectedVal, actualVal)

--- a/clients/go/coreutils/literals_test.go
+++ b/clients/go/coreutils/literals_test.go
@@ -397,8 +397,7 @@ func TestMakeLiteralForType(t *testing.T) {
 		var literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_INTEGER}}
 		_, err := MakeLiteralForType(literalType, 8.888888e+19)
 		assert.NotNil(t, err)
-		var numError error
-		numError = &strconv.NumError{
+		numError := &strconv.NumError{
 			Func: "ParseInt",
 			Num:  "88888880000000000000",
 			Err:  fmt.Errorf("value out of range"),


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Parsing large integers breaks in flytectl since by default json unmarshal converts the number to float64 representation
and when fmt.Sprinf is done for such a value then by default for large floats it uses exponential representation which breaks the parsing 
when it tries to do this `strconv.ParseInt("8.888888e+06")`

```
Error: failed to parse integer value: strconv.ParseInt: parsing "8.888888e+06": invalid syntax
```

The fix is to check for the type of float64 and compare the truncated integer portion with the actual float64 value and if they are equal then use %.0f formatter to remove the decimal part in the string.



Test with integer within bounds
```
cat lp.yaml 
iamRoleARN: ""
inputs:
  am: false
  day_of_week: 2
  number: 88888888
kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
version: v1
workflow: core.flyte_basics.lp.go_greet

 flytectl create execution -p flytesnacks -d development --execFile lp.yaml
execution identifier project:"flytesnacks" domain:"development" name:"f586641988abb438294e" 
```

Test with integer out of bounds

```
cat lp.yaml
iamRoleARN: ""
inputs:
  am: false
  day_of_week: 2
  number: 88888888888888888888
kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
version: v1
workflow: core.flyte_basics.lp.go_greet

flytectl create execution -p flytesnacks -d development --execFile lp.yaml
Error: failed to parse integer value: strconv.ParseInt: parsing "88888888888888885248": value out of range
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1282

## Follow-up issue
_NA_