### PR TITLE
Disable bump-version and goreleaser workflow in the forked repository

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   bump-version:
+    if: github.repository == 'flyteorg/flyteidl'
     name: Bump Version
     runs-on: ubuntu-latest
     outputs:
@@ -24,6 +25,7 @@ jobs:
           DEFAULT_BUMP: patch
 
   goreleaser:
+    if: github.repository == 'flyteorg/flyteidl'
     name: Goreleaser
     runs-on: ubuntu-latest
     needs: [bump-version]

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-version:
-    if: github.repository == 'flyteorg/flyteidl'
+    if: github.repository == 'flyteorg/flyteidl' 
     name: Bump Version
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-version:
-    if: github.repository == 'flyteorg/flyteidl' 
+    if: github.repository == 'flyteorg/flyteidl'
     name: Bump Version
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
# TL;DR
Disable bump-version and goreleaser in the forked repository, since fork can not find the GitHub secret
Github Action error message: https://github.com/pingsutw/flyteidl/runs/3325279069


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
only run the workflow in `flyteorg/flyteidl`

## Tracking Issue

## Follow-up issue
_NA_
