### PR TITLE
fix timestamp and duration literal extraction

### DIFF
--- a/clients/go/coreutils/extract_literal.go
+++ b/clients/go/coreutils/extract_literal.go
@@ -46,10 +46,10 @@ func ExtractFromLiteral(literal *core.Literal) (interface{}, error) {
 				scalarPrimitiveBoolean := scalarPrimitive.Boolean
 				return scalarPrimitiveBoolean, nil
 			case *core.Primitive_Datetime:
-				scalarPrimitiveDateTime := scalarPrimitive.Datetime
+				scalarPrimitiveDateTime := scalarPrimitive.Datetime.AsTime()
 				return scalarPrimitiveDateTime, nil
 			case *core.Primitive_Duration:
-				scalarPrimitiveDuration := scalarPrimitive.Duration
+				scalarPrimitiveDuration := scalarPrimitive.Duration.AsDuration()
 				return scalarPrimitiveDuration, nil
 			default:
 				return nil, fmt.Errorf("unsupported literal scalar primitive type %T", scalarValue)

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -4,6 +4,7 @@
 package coreutils
 
 import (
+	"time"
 	"testing"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
@@ -19,6 +20,24 @@ func TestFetchLiteral(t *testing.T) {
 		val, err := ExtractFromLiteral(lit)
 		assert.NoError(t, err)
 		assert.Equal(t, "test_string", val)
+	})
+
+	t.Run("Timestamp", func(t *testing.T) {
+		now := time.Now().UTC()
+		lit, err := MakeLiteral(now)
+		assert.NoError(t, err)
+		val, err := ExtractFromLiteral(lit)
+		assert.NoError(t, err)
+		assert.Equal(t, now, val)
+	})
+
+	t.Run("Duration", func(t *testing.T) {
+		duration := time.Second * 10
+		lit, err := MakeLiteral(duration)
+		assert.NoError(t, err)
+		val, err := ExtractFromLiteral(lit)
+		assert.NoError(t, err)
+		assert.Equal(t, duration, val)
 	})
 
 	t.Run("Array", func(t *testing.T) {

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -4,8 +4,8 @@
 package coreutils
 
 import (
-	"time"
 	"testing"
+	"time"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 


### PR DESCRIPTION
# TL;DR
Instead of returning timestamp and duration protobufs in the ExtractFromLiteral function we return native golang timestamp and duration types. This functionality aligns with the existing approach in the MakeLiterals timestamp and duration case, changing native golang types into timestamp and duration protobufs.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added .AsTime() and .AsDuration() to the ExtractFromLiteral function in the golang client. This function is used to change protobuf types to native golang types. Flytectl relies on this to write execution specification files on the 'get launchplan' command. Currently sequentially applying MakeLiteral and ExtractFromLiteral to convert a type to protobuf and back to a golang native type may be applied to retrieve the original datatype. However, this is not the case for timestamp and duration types which seems to be an error.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1380
fixes https://github.com/flyteorg/flyte/issues/1399

## Follow-up issue
_NA_
