### PR TITLE
Schema type support for flytectl

### DIFF
--- a/clients/go/coreutils/extract_literal.go
+++ b/clients/go/coreutils/extract_literal.go
@@ -56,6 +56,8 @@ func ExtractFromLiteral(literal *core.Literal) (interface{}, error) {
 			}
 		case *core.Scalar_Blob:
 			return scalarValue.Blob.Uri, nil
+		case *core.Scalar_Schema:
+			return scalarValue.Schema.Uri, nil
 		case *core.Scalar_Generic:
 			return scalarValue.Generic, nil
 		default:

--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -462,9 +462,8 @@ func MakeLiteralForBlob(path storage.DataReference, isDir bool, format string) *
 
 func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, error) {
 	l := &core.Literal{}
-	switch t.Type.(type) {
+	switch newT := t.Type.(type) {
 	case *core.LiteralType_MapValueType:
-		newT := t.Type.(*core.LiteralType_MapValueType)
 		newV, ok := v.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("map value types can only be of type map[string]interface{}, but found %v", reflect.TypeOf(v))
@@ -485,7 +484,6 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		}
 
 	case *core.LiteralType_CollectionType:
-		newT := t.Type.(*core.LiteralType_CollectionType)
 		newV, ok := v.([]interface{})
 		if !ok {
 			return nil, fmt.Errorf("collection type expected but found %v", reflect.TypeOf(v))
@@ -506,7 +504,6 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		}
 
 	case *core.LiteralType_Simple:
-		newT := t.Type.(*core.LiteralType_Simple)
 		strValue := fmt.Sprintf("%v", v)
 		if v == nil {
 			strValue = ""
@@ -534,13 +531,11 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 		return lv, nil
 
 	case *core.LiteralType_Blob:
-		newT := t.Type.(*core.LiteralType_Blob)
 		isDir := newT.Blob.Dimensionality == core.BlobType_MULTIPART
 		lv := MakeLiteralForBlob(storage.DataReference(fmt.Sprintf("%v", v)), isDir, newT.Blob.Format)
 		return lv, nil
 
 	case *core.LiteralType_Schema:
-		newT := t.Type.(*core.LiteralType_Schema)
 		lv := MakeLiteralForSchema(storage.DataReference(fmt.Sprintf("%v", v)), newT.Schema.Columns)
 		return lv, nil
 


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Schema type support for flytectl

Tested pandera total_pay example for this.

####  Before the fix Create execution spec file
```
flytectl get task  -p flytesnacks -d development pandera_examples.basic_schema_example.total_pay --latest --execFile t.yaml
error creating default value for literal type  schema:<columns:<name:"hourly_pay" type:FLOAT > columns:<name:"hours_worked" type:FLOAT > > 
Error: failed to convert to a known Literal. Input Type [schema:<columns:<name:"hourly_pay" type:FLOAT > columns:<name:"hours_worked" type:FLOAT > > ] not supported
```

#### After fix Create execution spec file
```
 flytectl get task  -p flytesnacks -d development pandera_examples.basic_schema_example.total_pay --latest --execFile t.yaml
warning file t.yaml will be overwritten [y/n]: y
 --------- ------------------------------------------------- ------------- -------- --------- -------------- ------------------- ----------------------------- 
| VERSION | NAME                                            | TYPE        | INPUTS | OUTPUTS | DISCOVERABLE | DISCOVERY VERSION | CREATED AT                  |
 --------- ------------------------------------------------- ------------- -------- --------- -------------- ------------------- ----------------------------- 
| v1      | pandera_examples.basic_schema_example.total_pay | python-task | df     | o0      |              |                   | 2021-09-08T13:23:19.754734Z |
 --------- ------------------------------------------------- ------------- -------- --------- -------------- ------------------- ----------------------------- 
```
#### Contents of the file
```
iamRoleARN: ""
inputs:
    df: s3://my-container/test/gs/n2gadshmve-n0-0/22872c2bb7fa62e50147293d2ad6f698/
kubeServiceAcct: ""
targetDomain: ""
targetProject: ""
task: pandera_examples.basic_schema_example.total_pay
version: v1
```

#### Creating execution
```
flytectl create execution -p flytesnacks -d development --execFile t.yaml
execution identifier project:"flytesnacks" domain:"development" name:"f3f059b7a662d49f0a9d"
```

<img width="1740" alt="Screenshot 2021-09-14 at 3 17 43 PM" src="https://user-images.githubusercontent.com/77798312/133235602-91ca6487-ed44-4b9d-b71f-e97849634638.png">



## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1314

## Follow-up issue
_NA_
