### PR TITLE
Update EventError with Is and Unwrap functions

### DIFF
--- a/clients/go/events/errors/errors.go
+++ b/clients/go/events/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -90,46 +91,25 @@ func wrapf(code ErrorCode, cause error, msg string) error {
 
 // Checks if the error is of type EventError and the ErrorCode is of type AlreadyExists
 func IsAlreadyExists(err error) bool {
-	e, ok := err.(*EventError)
-	if ok {
-		return e.Code == AlreadyExists
-	}
-	return false
+	return errors.Is(err, &EventError{Code: AlreadyExists})
 }
 
 // Checks if the error is of type EventError and the ErrorCode is of type InvalidArgument
 func IsInvalidArguments(err error) bool {
-	e, ok := err.(*EventError)
-	if ok {
-		return e.Code == InvalidArgument
-	}
-	return false
+	return errors.Is(err, &EventError{Code: InvalidArgument})
 }
 
 // Checks if the error is of type EventError and the ErrorCode is of type ExecutionNotFound
 func IsNotFound(err error) bool {
-	e, ok := err.(*EventError)
-	if ok {
-		return e.Code == ExecutionNotFound
-	}
-	return false
+	return errors.Is(err, &EventError{Code: ExecutionNotFound})
 }
 
 // Checks if the error is of type EventError and the ErrorCode is of type ResourceExhausted
 func IsResourceExhausted(err error) bool {
-	e, ok := err.(*EventError)
-	if ok {
-		return e.Code == ResourceExhausted
-	}
-	return false
+	return errors.Is(err, &EventError{Code: ResourceExhausted})
 }
 
 // Checks if the error is of type EventError and the ErrorCode is of type EventAlreadyInTerminalStateError
 func IsEventAlreadyInTerminalStateError(err error) bool {
-	// TODO: don't rely on the specific type here as it could be wrapped in another object.
-	e, ok := err.(*EventError)
-	if ok {
-		return e.Code == EventAlreadyInTerminalStateError
-	}
-	return false
+	return errors.Is(err, &EventError{Code: EventAlreadyInTerminalStateError})
 }

--- a/clients/go/events/errors/errors.go
+++ b/clients/go/events/errors/errors.go
@@ -37,6 +37,12 @@ func (r *EventError) Is(target error) bool {
 	if !ok {
 		return false
 	}
+	if r == nil && t == nil {
+		return true
+	}
+	if r == nil || t == nil {
+		return false
+	}
 	return r.Code == t.Code && (r.Cause == t.Cause || t.Cause == nil) && (r.Message == t.Message || t.Message == "")
 }
 

--- a/clients/go/events/errors/errors.go
+++ b/clients/go/events/errors/errors.go
@@ -31,6 +31,18 @@ func (r EventError) Error() string {
 	return fmt.Sprintf("%s: %s, caused by [%s]", r.Code, r.Message, r.Cause.Error())
 }
 
+func (r *EventError) Is(target error) bool {
+	t, ok := target.(*EventError)
+	if !ok {
+		return false
+	}
+	return r.Code == t.Code && (r.Cause == t.Cause || t.Cause == nil) && (r.Message == t.Message || t.Message == "")
+}
+
+func (r *EventError) Unwrap() error {
+	return r.Cause
+}
+
 func WrapError(err error) error {
 	// check if error is gRPC, and convert into our own custom error
 	statusErr, ok := status.FromError(err)


### PR DESCRIPTION
Signed-off-by: Daniel Rammer <daniel@union.ai>

# TL;DR
The golang errors package provides the functions Is (to check if an instance of the error type is within the stack), As (to convert the error to the error type if it is within the stack), and Unwrap (to facilitate the aforementioned functionality). This updates the EventError type to enable use within the API.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See TL;DR

## Tracking Issue
_NA_

## Follow-up issue
_NA_