### PR TITLE
Adding grpc health service in the clientset

### DIFF
--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -38,7 +38,7 @@ var (
 type Clientset struct {
 	adminServiceClient        service.AdminServiceClient
 	authMetadataServiceClient service.AuthMetadataServiceClient
-	healthServiceClient 	  grpc_health_v1.HealthClient
+	healthServiceClient       grpc_health_v1.HealthClient
 	identityServiceClient     service.IdentityServiceClient
 }
 

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -72,6 +72,7 @@ func TestGetAdditionalAdminClientConfigOptions(t *testing.T) {
 		assert.NotNil(t, clientSet.AdminClient())
 		assert.NotNil(t, clientSet.AuthMetadataClient())
 		assert.NotNil(t, clientSet.IdentityClient())
+		assert.NotNil(t, clientSet.HealthServiceClient())
 	})
 
 	t.Run("legal-from-config", func(t *testing.T) {
@@ -80,6 +81,7 @@ func TestGetAdditionalAdminClientConfigOptions(t *testing.T) {
 		assert.NotNil(t, clientSet)
 		assert.NotNil(t, clientSet.AuthMetadataClient())
 		assert.NotNil(t, clientSet.AdminClient())
+		assert.NotNil(t, clientSet.HealthServiceClient())
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Flytescheduler checks for the health of the admin before bringing itself up.
Earlier these checks were done by creating health client in the scheduler and passing some set of grpc dial options.
These grpc dial options were insufficient in cases of authenticated admins.

This change adds the HealthClient as part of the clientset which underneath takes care of setting the right dial options based on the admin configuration.


Testing done : 
Using the same in flytescheduler-check 

```
kubectl logs -f flytescheduler-7cb7969699-nkqll -n flyte flytescheduler-check
Using config file:  [/etc/flyte/config/admin.yaml /etc/flyte/config/db.yaml /etc/flyte/config/logger.yaml]
{"json":{"src":"client.go:181"},"level":"error","msg":"failed to initialize token source provider. Err: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: i/o timeout\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:186"},"level":"warning","msg":"Starting an unauthenticated client because: can't create authenticated channel without a TokenSourceProvider","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:17Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:18Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"precheck.go:32"},"level":"error","msg":"Attempt failed due to rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.108.135.159:81: connect: connection refused\"","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"client.go:65"},"level":"info","msg":"Initialized Admin client","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"precheck.go:52"},"level":"info","msg":"Health check response is status:SERVING","ts":"2021-10-28T16:12:19Z"}
{"json":{"src":"precheck.go:61"},"level":"info","msg":"Health check passed, Flyteadmin is up and running","ts":"2021-10-28T16:12:19Z"}
```

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1753

## Follow-up issue
NA
