### PR TITLE
bump docsearch version

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,9 +13,9 @@ beautifulsoup4==4.10.0
     #   furo
     #   sphinx-code-include
     #   sphinx-material
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.10
     # via requests
 commonmark==0.9.1
     # via recommonmark
@@ -27,41 +27,43 @@ docutils==0.17.1
     #   sphinx
 furo @ git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
-idna==3.2
+idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.1
+importlib-metadata==4.10.0
+    # via markdown
+jinja2==3.0.3
     # via sphinx
-lxml==4.6.3
+lxml==4.7.1
     # via sphinx-material
-markdown==3.3.4
+markdown==3.3.6
     # via sphinx-markdown-tables
 markupsafe==2.0.1
     # via jinja2
-packaging==21.0
+packaging==21.3
     # via sphinx
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   sphinx
     #   sphinx-prompt
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 python-slugify[unidecode]==5.0.2
     # via sphinx-material
-pytz==2021.1
+pytz==2021.3
     # via babel
 recommonmark==0.7.1
     # via -r doc-requirements.in
-requests==2.26.0
+requests==2.27.1
     # via sphinx
 six==1.16.0
     # via sphinx-code-include
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.2.1
+soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r doc-requirements.in
     #   furo
@@ -79,7 +81,7 @@ sphinx-fontawesome==0.0.6
     # via -r doc-requirements.in
 sphinx-markdown-tables==0.0.15
     # via -r doc-requirements.in
-sphinx-material==0.0.34
+sphinx-material==0.0.35
     # via -r doc-requirements.in
 sphinx-prompt==1.5.0
     # via -r doc-requirements.in
@@ -101,6 +103,8 @@ unidecode==1.3.2
     # via python-slugify
 urllib3==1.26.7
     # via requests
+zipp==3.7.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

## _Read then delete this section_

_- Make sure to use a concise title for the pull-request._

_- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version
will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)_

# TL;DR
- Pull updated Algolia search creds from furo repo
- Bump docsearch from v2 to v3

<img width="1362" alt="Screenshot 2022-01-07 at 4 18 37 PM" src="https://user-images.githubusercontent.com/27777173/148533666-b2839a0c-806e-4cde-8382-3c13b3f5d1f6.png">

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2030

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
