### PR TITLE
Expose flyteadmin client's auth opt

### DIFF
--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -215,7 +215,9 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 	cs.authMetadataServiceClient = service.NewAuthMetadataServiceClient(adminConnection)
 	cs.identityServiceClient = service.NewIdentityServiceClient(adminConnection)
 	cs.healthServiceClient = grpc_health_v1.NewHealthClient(adminConnection)
-	cs.authOpt = *authOpt
+	if authOpt != nil {
+		cs.authOpt = *authOpt
+	}
 	return &cs, nil
 }
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -28,6 +28,7 @@ import (
 var (
 	once            = sync.Once{}
 	adminConnection *grpc.ClientConn
+	authOpt         *grpc.DialOption
 
 	// A new connection just for auth metadata service since it will be used to retrieve auth
 	// related information that's needed to initialize the Clientset.
@@ -182,7 +183,6 @@ func InitializeAdminClient(ctx context.Context, cfg *Config, opts ...grpc.DialOp
 // initializeClients creates an AdminClient, AuthServiceClient and IdentityServiceClient with a shared Admin connection
 // for the process. Note that if called with different cfg/dialoptions, it will not refresh the connection.
 func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCache, opts ...grpc.DialOption) (*Clientset, error) {
-	var cs Clientset
 	once.Do(func() {
 		authMetadataClient, err := InitializeAuthMetadataClient(ctx, cfg)
 		if err != nil {
@@ -200,8 +200,8 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		}
 
 		if opt != nil {
-			cs.authOpt = opt
 			opts = append(opts, opt)
+			authOpt = &opt
 		}
 
 		adminConnection, err = NewAdminConnection(ctx, cfg, opts...)
@@ -210,10 +210,12 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		}
 	})
 
+	var cs Clientset
 	cs.adminServiceClient = NewAdminClient(ctx, adminConnection)
 	cs.authMetadataServiceClient = service.NewAuthMetadataServiceClient(adminConnection)
 	cs.identityServiceClient = service.NewIdentityServiceClient(adminConnection)
 	cs.healthServiceClient = grpc_health_v1.NewHealthClient(adminConnection)
+	cs.authOpt = *authOpt
 	return &cs, nil
 }
 


### PR DESCRIPTION
# TL;DR
This PR together with https://github.com/flyteorg/flytepropeller/pull/389 enable services i.e. datacatalog to use flyteadmin as the authorization server.
The flyteadmin client set utilizes flyteadmin in the same way in client.go:
```
// initializeClients creates an AdminClient, AuthServiceClient and IdentityServiceClient with a shared Admin connection
// for the process. Note that if called with different cfg/dialoptions, it will not refresh the connection.
func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCache, opts ...grpc.DialOption) (*Clientset, error) {
	once.Do(func() {
		authMetadataClient, err := InitializeAuthMetadataClient(ctx, cfg)
		if err != nil {
			logger.Panicf(ctx, "failed to initialize Auth Metadata Client. Error: %v", err)
		}

		// If auth is enabled, this call will return the required information to use to authenticate, otherwise,
		// start the client without authentication.
		opt, err := getAuthenticationDialOption(ctx, cfg, tokenCache, authMetadataClient)
		if err != nil {
			logger.Warnf(ctx, "Starting an unauthenticated client because: %v", err)
		}

		if opt != nil {
			opts = append(opts, opt)
		}

		adminConnection, err = NewAdminConnection(ctx, cfg, opts...)
		if err != nil {
			logger.Panicf(ctx, "failed to initialize Admin connection. Err: %s", err.Error())
		}
	})

	var cs Clientset
	cs.adminServiceClient = NewAdminClient(ctx, adminConnection)
	cs.authMetadataServiceClient = service.NewAuthMetadataServiceClient(adminConnection)
	cs.identityServiceClient = service.NewIdentityServiceClient(adminConnection)
	return &cs, nil
}
```
By exposing the authentication gRPC option, other clients may use it directly during client initialization. The downside is that this only works when flyteadmin is used as the authorization server.

#### Alternative solution:
Allow datacatalog to be configured individually for OIDC authentication flow. The datacatalog client need to be configured similar to the flyteadmin client:
```
type Config struct {
	Endpoint              config.URL      `json:"endpoint" pflag:",For admin types, specify where the uri of the service is located."`
	UseInsecureConnection bool            `json:"insecure" pflag:",Use insecure connection."`
	MaxBackoffDelay       config.Duration `json:"maxBackoffDelay" pflag:",Max delay for grpc backoff"`
	PerRetryTimeout       config.Duration `json:"perRetryTimeout" pflag:",gRPC per retry timeout"`
	MaxRetries            int             `json:"maxRetries" pflag:",Max number of gRPC retries"`
	AuthType              AuthType        `json:"authType" pflag:"-,Type of OAuth2 flow used for communicating with admin."`
	// Deprecated: settings will be discovered dynamically
	DeprecatedUseAuth    bool     `json:"useAuth" pflag:",Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information."`
	ClientID             string   `json:"clientId" pflag:",Client ID"`
	ClientSecretLocation string   `json:"clientSecretLocation" pflag:",File containing the client secret"`
	Scopes               []string `json:"scopes" pflag:",List of scopes to request"`

	// There are two ways to get the token URL. If the authorization server url is provided, the client will try to use RFC 8414 to
	// try to get the token URL. Or it can be specified directly through TokenURL config.
	// Deprecated: This will now be discovered through admin's anonymously accessible metadata.
	DeprecatedAuthorizationServerURL string `json:"authorizationServerUrl" pflag:",This is the URL to your IdP's authorization server. It'll default to Endpoint"`
	// If not provided, it'll be discovered through admin's anonymously accessible metadata endpoint.
	TokenURL string `json:"tokenUrl" pflag:",OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided."`

	// See the implementation of the 'grpcAuthorizationHeader' option in Flyte Admin for more information. But
	// basically we want to be able to use a different string to pass the token from this client to the the Admin service
	// because things might be running in a service mesh (like Envoy) that already uses the default 'authorization' header
	// Deprecated: It will automatically be discovered through an anonymously accessible auth metadata service.
	DeprecatedAuthorizationHeader string `json:"authorizationHeader" pflag:",Custom metadata header to pass JWT"`

	PkceConfig pkce.Config `json:"pkceConfig" pflag:",Config for Pkce authentication flow."`
}
```
This potentially supports other OIDC setups. However, the aforementioned auth flow is very closely coupled with flyteadmin and `DeprecatedAuthorizationServerURL` is deprecated. Flyteidl will have to support vanilla OIDC auth flow.
TL;DR of TL;DR: solution A supports flyteadmin auth only, solution B supports other OIDC setup but needs work.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue

## Follow-up issue
_NA_
