### PR TITLE
Add missing Python libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
     package_dir={'': 'gen/pb_python'},
     dependency_links=[],
     install_requires=[
+        'googleapis-common-protos',
+        'protoc_gen_swagger',
         'protobuf>=3.5.0,<4.0.0',
         # Packages in here should rarely be pinned. This is because these
         # packages (at the specified version) are required for project


### PR DESCRIPTION
# TL;DR
Add missing Python libs.  We only now started importing generated code from the service folder.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
On a new venv, just installing flyteidl you'd currently get
```
$ python
Python 3.8.9 (default, Apr  3 2021, 01:50:09)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from flyteidl.service import auth_pb2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ytong/envs/goob/lib/python3.8/site-packages/flyteidl/service/auth_pb2.py", line 16, in <module>
    from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
ModuleNotFoundError: No module named 'google.api'
```
and
```
>>> from flyteidl.service import admin_pb2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ytong/envs/goob2/lib/python3.8/site-packages/flyteidl/service/admin_pb2.py", line 30, in <module>
    from protoc_gen_swagger.options import annotations_pb2 as protoc__gen__swagger_dot_options_dot_annotations__pb2
ModuleNotFoundError: No module named 'protoc_gen_swagger'
```

## Tracking Issue
