### PR TITLE
Add workflow execution JSON schema

### DIFF
--- a/jsonschema/README.md
+++ b/jsonschema/README.md
@@ -3,4 +3,15 @@
 This folder contains the JSON Schema of execution event, and this schema will
 be used by [cloudevent publisher](https://github.com/flyteorg/flyteadmin/blob/a0ca4b07d3b1c3cccfe3830307df50bc73152ddb/pkg/async/cloudevent/implementations/cloudevent_publisher.go#L96).
 
-Schema URL points to the JSON file that will be sent along with cloudevent
+The URL for the JSON file will be included with the cloudevent message. For example
+```json
+{
+    "specversion" : "1.0",
+    "type" : "com.flyte.resource.workflow",
+    "source" : "https://github.com/flyteorg/flyteadmin",
+    "id" : "D234-1234-1234",
+    "time" : "2018-04-05T17:31:00Z",
+    "jsonschemaurl": "https://github.com/flyteorg/flyteidl/blob/master/jsonschema/workflow_execution.json",
+    "data" : "workflow execution event"
+}
+```

--- a/jsonschema/README.md
+++ b/jsonschema/README.md
@@ -1,0 +1,6 @@
+# JSON SCHEMA
+
+This folder contains the JSON Schema of execution event, and this schema will
+be used by [cloudevent publisher](https://github.com/flyteorg/flyteadmin/blob/a0ca4b07d3b1c3cccfe3830307df50bc73152ddb/pkg/async/cloudevent/implementations/cloudevent_publisher.go#L96).
+
+Schema URL points to the JSON file that will be sent along with cloudevent

--- a/jsonschema/workflow_execution.json
+++ b/jsonschema/workflow_execution.json
@@ -2,32 +2,40 @@
   "$schema": "http://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin/workflow-execution-event-request",
   "properties": {
-    "execution_id": {
-      "$ref": "#/$defs/WorkflowExecutionIdentifier"
-    },
-    "producer_id": {
+    "RequestId": {
       "type": "string"
     },
-    "phase": {
-      "type": "integer"
-    },
-    "occurred_at": {
-      "$ref": "#/$defs/Timestamp"
-    },
-    "output_result": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "output_uri": {
-              "type": "string"
-            }
-          }
+    "Event": {
+      "type": "object",
+      "properties": {
+        "execution_id": {
+          "$ref": "#/$defs/WorkflowExecutionIdentifier"
         },
-        {
-          "$ref": "#/$defs/ExecutionError"
+        "producer_id": {
+          "type": "string"
+        },
+        "phase": {
+          "type": "integer"
+        },
+        "occurred_at": {
+          "$ref": "#/$defs/Timestamp"
+        },
+        "output_result": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "output_uri": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "$ref": "#/$defs/ExecutionError"
+            }
+          ]
         }
-      ]
+      }
     }
   },
   "$defs": {

--- a/jsonschema/workflow_execution.json
+++ b/jsonschema/workflow_execution.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin/workflow-execution-event-request",
+  "properties": {
+    "execution_id": {
+      "$ref": "#/$defs/WorkflowExecutionIdentifier"
+    },
+    "producer_id": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "integer"
+    },
+    "occurred_at": {
+      "$ref": "#/$defs/Timestamp"
+    },
+    "output_result": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "output_uri": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "#/$defs/ExecutionError"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "WorkflowExecutionIdentifier": {
+      "properties": {
+        "project": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Timestamp": {
+      "properties": {
+        "seconds": {
+          "type": "integer"
+        },
+        "nanos": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExecutionError": {
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "error_uri": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Define workflow execution JSON schema, so the users can know the event schema when fetching cloudevent from SNS

Flyte admin will publish a cloudevent with the attribute *jsonSchemaURL* and the value `https://github.com/flyteorg/flyteidl/jsonschema/workflow_execution.json`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
had already used online JSON schema validator to check the syntax
https://www.jsonschemavalidator.net/

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1019

## Follow-up issue
_NA_
