### PR TITLE
Fix pattern to hide generated code in github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 gen/** linguist-generated=true
+protos/**/*.rst linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-gen/* linguist-generated=true
+gen/** linguist-generated=true


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Fix pattern used to hide generated code in github by default

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This is more of a quality of life feature to aid reviewers of `flyteidl` PRs.

The `linguist-generated=true` pattern uses the [git pattern format,](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) which specifies that in order to match all files under a path we have to specify `**`.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
