### PR TITLE
Change default npm/python versions to valid semver #patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ doc_gen_deps:
 doc-requirements.txt: doc-requirements.in install-piptools
 	$(call PIP_COMPILE,doc-requirements.in)
 
-PLACEHOLDER := "__version__\ =\ \"develop\""
-PLACEHOLDER_NPM := \"version\": \"develop\"
+PLACEHOLDER := "__version__\ =\ \"0.0.0+develop\""
+PLACEHOLDER_NPM := \"version\": \"0.0.0-develop\"
 
 .PHONY: update_pyversion
 update_pyversion:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/flyteidl",
-  "version": "develop",
+  "version": "0.0.0-develop",
   "description": "Compiled protocol buffers and gRPC service clients/servers for Flyte IDLs",
   "repository": {
     "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "develop"
+__version__ = "0.0.0+develop"
 
 setup(
     name='flyteidl',


### PR DESCRIPTION
# TL;DR
Updated the default (develop) version specified in `package.json`/`setup.py` files to contain valid semver.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The version specified for the npm/python package generated from flyteidl is set to `"develop"`, which is not valid semver format and leads to npm/yarn refusing to use the repository as a [git dependency](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies).
This PR changes the default version to `0.0.0-develop` and `0.0.0+develop` for npm and python respectively, remaining the clear indication that anything packages from this is a development build while ensuring no accidental upgrades to this package will be performed as its version number is below anything published and the appended `-+develop` makes it a pre-release/local version with even lower priority.
A similar setup already exists for the python package of the [flytekit](https://github.com/flyteorg/flytekit/blob/master/setup.py#L16) [repository](https://github.com/flyteorg/flytekit/blob/master/Makefile#L84).

As mentioned in the [issue](https://github.com/flyteorg/flyte/issues/2408), the main benefit of this would be PRs to flyteconsole using unreleased versions of flyteidl as well as the option for (private) forks of flyte to use the flyteidl repository as a direct dependency for npm (and potentially python, although untested).

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/2408

## Follow-up issue
_NA_
