### PR TITLE
Grpc default service config

### DIFF
--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	_ "google.golang.org/grpc/balancer/grpclb" //nolint
+	_ "google.golang.org/grpc/balancer/grpclb"     //nolint
 	_ "google.golang.org/grpc/balancer/roundrobin" //nolint
 )
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -19,8 +19,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	_ "google.golang.org/grpc/balancer/grpclb"
-	_ "google.golang.org/grpc/balancer/roundrobin"
+	_ "google.golang.org/grpc/balancer/grpclb" //nolint
+	_ "google.golang.org/grpc/balancer/roundrobin" //nolint
 )
 
 // IDE "Go Generate File". This will create a mocks/AdminServiceClient.go file

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -192,6 +192,10 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		opts = append(opts, authOpt)
 	}
 
+	if cfg.Balancer != "" {
+		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.Balancer)))
+	}
+
 	adminConnection, err := NewAdminConnection(ctx, cfg, opts...)
 	if err != nil {
 		logger.Panicf(ctx, "failed to initialize Admin connection. Err: %s", err.Error())

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -199,7 +199,6 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		// The grpcClient will be created regardless of the value of the loadBalancingPolicy.
 		// When a balancing policy cannot be found, the client will be created with `pick_first`.
 		// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
-		// TODO: test that the loadBalancingPolicy is configured properly and validate towards the value from the grpc.clientConn
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.LoadBalancingPolicy)))
 	}
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -196,9 +196,6 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 	}
 
 	if cfg.LoadBalancingPolicy != "" {
-		// The grpcClient will be created regardless of the value of the loadBalancingPolicy.
-		// When a balancing policy cannot be found, the client will be created with `pick_first`.
-		// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.LoadBalancingPolicy)))
 	}
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -18,9 +18,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
-
-	_ "google.golang.org/grpc/balancer/grpclb"     //nolint
-	_ "google.golang.org/grpc/balancer/roundrobin" //nolint
 )
 
 // IDE "Go Generate File". This will create a mocks/AdminServiceClient.go file
@@ -195,8 +192,8 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		opts = append(opts, authOpt)
 	}
 
-	if cfg.ServiceConfig != "" {
-		opts = append(opts, grpc.WithDefaultServiceConfig(cfg.ServiceConfig))
+	if cfg.DefaultServiceConfig != "" {
+		opts = append(opts, grpc.WithDefaultServiceConfig(cfg.DefaultServiceConfig))
 	}
 
 	adminConnection, err := NewAdminConnection(ctx, cfg, opts...)

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -18,6 +18,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	_ "google.golang.org/grpc/balancer/grpclb"
+	_ "google.golang.org/grpc/balancer/roundrobin"
 )
 
 // IDE "Go Generate File". This will create a mocks/AdminServiceClient.go file

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -193,7 +193,7 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 	}
 
 	if cfg.Balancer != "" {
-		// policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
+		// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.Balancer)))
 	}
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -192,9 +192,12 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		opts = append(opts, authOpt)
 	}
 
-	if cfg.Balancer != "" {
+	if cfg.LoadBalancingPolicy != "" {
+		// The grpcClient will be created regardless of the value of the loadBalancingPolicy.
+		// When a balancing policy cannot be found, the client will be created with `pick_first`.
 		// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
-		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.Balancer)))
+		// TODO: test that the loadBalancingPolicy is configured properly and validate towards the value from the grpc.clientConn
+		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.LoadBalancingPolicy)))
 	}
 
 	adminConnection, err := NewAdminConnection(ctx, cfg, opts...)

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -195,8 +195,8 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 		opts = append(opts, authOpt)
 	}
 
-	if cfg.LoadBalancingPolicy != "" {
-		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.LoadBalancingPolicy)))
+	if cfg.ServiceConfig != "" {
+		opts = append(opts, grpc.WithDefaultServiceConfig(cfg.ServiceConfig))
 	}
 
 	adminConnection, err := NewAdminConnection(ctx, cfg, opts...)

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -193,6 +193,7 @@ func initializeClients(ctx context.Context, cfg *Config, tokenCache pkce.TokenCa
 	}
 
 	if cfg.Balancer != "" {
+		// policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%v"}`, cfg.Balancer)))
 	}
 

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -276,33 +276,3 @@ func ExampleClientSetBuilder() {
 	_ = clientSet.AuthMetadataClient()
 	_ = clientSet.IdentityClient()
 }
-
-func TestBalancerConfigs(t *testing.T) {
-	u, _ := url.Parse("localhost:8089")
-	adminServiceConfig := &Config{
-		Endpoint:              config.URL{URL: *u},
-		UseInsecureConnection: true,
-		Balancer:              "round_robin",
-	}
-
-	assert.NoError(t, SetConfig(adminServiceConfig))
-
-	ctx := context.Background()
-	t.Run("legal", func(t *testing.T) {
-		u, err := url.Parse("http://localhost:8089")
-		assert.NoError(t, err)
-		clientSet, err := ClientSetBuilder().WithConfig(&Config{Endpoint: config.URL{URL: *u}}).Build(ctx)
-		assert.NoError(t, err)
-		assert.NotNil(t, clientSet)
-		assert.NotNil(t, clientSet.AdminClient())
-		assert.NotNil(t, clientSet.AuthMetadataClient())
-		assert.NotNil(t, clientSet.IdentityClient())
-		assert.NotNil(t, clientSet.HealthServiceClient())
-	})
-
-	t.Run("legal-from-config", func(t *testing.T) {
-		clientSet, err := initializeClients(ctx, adminServiceConfig, nil)
-		assert.NoError(t, err)
-		assert.NotNil(t, clientSet)
-	})
-}

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -276,3 +276,34 @@ func ExampleClientSetBuilder() {
 	_ = clientSet.AuthMetadataClient()
 	_ = clientSet.IdentityClient()
 }
+
+
+func TestBalancerConfigs(t *testing.T) {
+	u, _ := url.Parse("localhost:8089")
+	adminServiceConfig := &Config{
+		Endpoint:              config.URL{URL: *u},
+		UseInsecureConnection: true,
+		Balancer: 			   "round_robin",
+	}
+
+	assert.NoError(t, SetConfig(adminServiceConfig))
+
+	ctx := context.Background()
+	t.Run("legal", func(t *testing.T) {
+		u, err := url.Parse("http://localhost:8089")
+		assert.NoError(t, err)
+		clientSet, err := ClientSetBuilder().WithConfig(&Config{Endpoint: config.URL{URL: *u}}).Build(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, clientSet)
+		assert.NotNil(t, clientSet.AdminClient())
+		assert.NotNil(t, clientSet.AuthMetadataClient())
+		assert.NotNil(t, clientSet.IdentityClient())
+		assert.NotNil(t, clientSet.HealthServiceClient())
+	})
+
+	t.Run("legal-from-config", func(t *testing.T) {
+		clientSet, err := initializeClients(ctx, adminServiceConfig, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, clientSet)
+	})
+}

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -277,13 +277,12 @@ func ExampleClientSetBuilder() {
 	_ = clientSet.IdentityClient()
 }
 
-
 func TestBalancerConfigs(t *testing.T) {
 	u, _ := url.Parse("localhost:8089")
 	adminServiceConfig := &Config{
 		Endpoint:              config.URL{URL: *u},
 		UseInsecureConnection: true,
-		Balancer: 			   "round_robin",
+		Balancer:              "round_robin",
 	}
 
 	assert.NoError(t, SetConfig(adminServiceConfig))

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -68,9 +68,10 @@ type Config struct {
 
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
-	// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
-	// if the value of the LoadBalancingPolicy is not found, the grpc client will default to pick_first
-	LoadBalancingPolicy string `json:"loadBalancingPolicy" pdflag:",Set load balancing policy for grpc client"`
+	// Set the ServiceConfig formatted as a json string https://github.com/grpc/grpc/blob/master/doc/service_config.md
+	// eg. { "loadBalancingConfig": [{ "round_robin":{} }], "methodConfig": [{ "name": [{ "service": "foo", "method": "bar" }, { "service": "baz" }], "timeout": "1.000000001s"}]}
+	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625
+	ServiceConfig string `json:"serviceConfig" pdflag:",Set the service config for the grpc client"`
 }
 
 var (

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
 	// Set the gRPC service config formatted as a json string https://github.com/grpc/grpc/blob/master/doc/service_config.md
-	// eg. { "loadBalancingConfig": [{ "round_robin":{} }], "methodConfig": [{ "name": [{ "service": "foo", "method": "bar" }, { "service": "baz" }], "timeout": "1.000000001s"}]}
+	// eg. {"loadBalancingConfig": [{"round_robin":{}}], "methodConfig": [{"name":[{"service": "foo", "method": "bar"}, {"service": "baz"}], "timeout": "1.000000001s"}]}
 	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625
 	// Note that required packages may need to be preloaded to support certain service config. For example "google.golang.org/grpc/balancer/roundrobin" should be preloaded to have round-robin policy supported.
 	DefaultServiceConfig string `json:"defaultServiceConfig" pdflag:",Set the default service config for the admin gRPC client"`

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -69,6 +69,7 @@ type Config struct {
 
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
+	// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
 	Balancer string `json:"balancer" pdflag:",Set balancer for grpc client"`
 }
 

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -21,6 +21,7 @@ const (
 	DefaultClientID  = "flytepropeller"
 )
 
+
 var DefaultClientSecretLocation = filepath.Join(string(filepath.Separator), "etc", "secrets", "client_secret")
 
 //go:generate enumer --type=AuthType -json -yaml -trimprefix=AuthType

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -21,7 +21,6 @@ const (
 	DefaultClientID  = "flytepropeller"
 )
 
-
 var DefaultClientSecretLocation = filepath.Join(string(filepath.Separator), "etc", "secrets", "client_secret")
 
 //go:generate enumer --type=AuthType -json -yaml -trimprefix=AuthType

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -1,7 +1,6 @@
 // Initializes an Admin Client that exposes all implemented services by FlyteAdmin server. The library supports different
-// authentication flows (see AuthType). It initializes the grpc connection once and reuses it. The gRPC connection is
-// sticky (it hogs one server and keeps the connection alive). For better load balancing against the server, place a
-// proxy service in between instead.
+// authentication flows (see AuthType). It initializes the grpc connection once and reuses it. A grpc load balancing policy
+// can be configured as well.
 package admin
 
 import (
@@ -70,8 +69,8 @@ type Config struct {
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
 	// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
-	// if the value of the Balancer is not found, the grpc client will default to pick_first
-	Balancer string `json:"balancer" pdflag:",Set balancer for grpc client"`
+	// if the value of the LoadBalancingPolicy is not found, the grpc client will default to pick_first
+	LoadBalancingPolicy string `json:"loadBalancingPolicy" pdflag:",Set load balancing policy for grpc client"`
 }
 
 var (

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	PkceConfig pkce.Config `json:"pkceConfig" pflag:",Config for Pkce authentication flow."`
 
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
+
+	Balancer string `json:"balancer" pdflag:",Set balancer for grpc client"`
 }
 
 var (

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
 	// available policies can be found here https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#load-balancing-policies
+	// if the value of the Balancer is not found, the grpc client will default to pick_first
 	Balancer string `json:"balancer" pdflag:",Set balancer for grpc client"`
 }
 

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -68,10 +68,11 @@ type Config struct {
 
 	Command []string `json:"command" pflag:",Command for external authentication token generation"`
 
-	// Set the ServiceConfig formatted as a json string https://github.com/grpc/grpc/blob/master/doc/service_config.md
+	// Set the gRPC service config formatted as a json string https://github.com/grpc/grpc/blob/master/doc/service_config.md
 	// eg. { "loadBalancingConfig": [{ "round_robin":{} }], "methodConfig": [{ "name": [{ "service": "foo", "method": "bar" }, { "service": "baz" }], "timeout": "1.000000001s"}]}
 	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625
-	ServiceConfig string `json:"serviceConfig" pdflag:",Set the service config for the grpc client"`
+	// Note that required packages may need to be preloaded to support certain service config. For example "google.golang.org/grpc/balancer/roundrobin" should be preloaded to have round-robin policy supported.
+	DefaultServiceConfig string `json:"defaultServiceConfig" pdflag:",Set the default service config for the admin gRPC client"`
 }
 
 var (


### PR DESCRIPTION
# TL;DR
Add the ability to config gRPC default service config, to support e.g. load balancing policy.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This is a replacement/continuation of https://github.com/flyteorg/flyteidl/pull/298.

Add the ability to config gRPC default service config, to support e.g. load balancing policy.

## Tracking Issue
Partially address https://github.com/flyteorg/flyte/issues/2510

## Follow-up issue
https://github.com/flyteorg/flyte/issues/2510