### PR TITLE
Update execution.proto

### DIFF
--- a/gen/pb-go/flyteidl/core/execution.pb.go
+++ b/gen/pb-go/flyteidl/core/execution.pb.go
@@ -288,7 +288,7 @@ func (m *WorkflowExecution) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_WorkflowExecution proto.InternalMessageInfo
 
-// Indicates various phases of Node Execution
+// Indicates various phases of Node Execution that only include the time spent to run the nodes/workflows
 type NodeExecution struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/gen/pb-java/flyteidl/core/Execution.java
+++ b/gen/pb-java/flyteidl/core/Execution.java
@@ -609,7 +609,7 @@ public final class Execution {
   }
   /**
    * <pre>
-   * Indicates various phases of Node Execution
+   * Indicates various phases of Node Execution that only include the time spent to run the nodes/workflows
    * </pre>
    *
    * Protobuf type {@code flyteidl.core.NodeExecution}
@@ -1006,7 +1006,7 @@ public final class Execution {
     }
     /**
      * <pre>
-     * Indicates various phases of Node Execution
+     * Indicates various phases of Node Execution that only include the time spent to run the nodes/workflows
      * </pre>
      *
      * Protobuf type {@code flyteidl.core.NodeExecution}

--- a/protos/docs/core/core.rst
+++ b/protos/docs/core/core.rst
@@ -645,7 +645,7 @@ Represents the error message from the execution.
 NodeExecution
 ------------------------------------------------------------------
 
-Indicates various phases of Node Execution
+Indicates various phases of Node Execution that only include the time spent to run the nodes/workflows
 
 
 

--- a/protos/flyteidl/core/execution.proto
+++ b/protos/flyteidl/core/execution.proto
@@ -22,7 +22,7 @@ message WorkflowExecution {
     }
 }
 
-// Indicates various phases of Node Execution
+// Indicates various phases of Node Execution that only include the time spent to run the nodes/workflows
 message NodeExecution {
     enum Phase {
         UNDEFINED = 0;


### PR DESCRIPTION
[Slack conversation](https://flyte-org.slack.com/archives/C01P3B761A6/p1657755908722469)
The timeouts for nodes/workflows are configured using different config.go files, depending on the deadlines (such as `NodeExecution`, `NodeActive`, and `WorkflowActive` deadlines).
Specify about NodeExecution in the API docs that the times set by user includes only the time spent running.
Signed-off-by: SmritiSatyanV <smriti@union.ai>