### PR TITLE
Read client secret from env var first since the location has a default

### DIFF
--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -136,15 +136,15 @@ type ClientCredentialsTokenSourceProvider struct {
 func NewClientCredentialsTokenSourceProvider(ctx context.Context, cfg *Config,
 	clientMetadata *service.PublicClientAuthConfigResponse, tokenURL string) (TokenSourceProvider, error) {
 	var secret string
-	if len(cfg.ClientSecretLocation) > 0 {
+	if len(cfg.ClientSecretEnvVar) > 0 {
+		secret = os.Getenv(cfg.ClientSecretEnvVar)
+	} else if len(cfg.ClientSecretLocation) > 0 {
 		secretBytes, err := ioutil.ReadFile(cfg.ClientSecretLocation)
 		if err != nil {
 			logger.Errorf(ctx, "Error reading secret from location %s", cfg.ClientSecretLocation)
 			return nil, err
 		}
 		secret = string(secretBytes)
-	} else if len(cfg.ClientSecretEnvVar) > 0 {
-		secret = os.Getenv(cfg.ClientSecretEnvVar)
 	}
 	secret = strings.TrimSpace(secret)
 


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>
# TL;DR
Missed in https://github.com/flyteorg/flyteidl/pull/311
The client secret location has a default value so it's always non-empty and read before attempting to fetch the secret value.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/flyteorg/flyte/issues/2744

## Follow-up issue
_NA_
