### PR TITLE
Use grpc client interceptors to properly check for auth requirement

### DIFF
--- a/clients/go/admin/atomic_credentials.go
+++ b/clients/go/admin/atomic_credentials.go
@@ -1,0 +1,89 @@
+package admin
+
+import (
+	"context"
+	"sync/atomic"
+
+	"google.golang.org/grpc/credentials"
+
+	stdlibAtomic "github.com/flyteorg/flytestdlib/atomic"
+)
+
+// atomicPerRPCCredentials provides a convenience on top of atomic.Value and credentials.PerRPCCredentials to be thread-safe.
+type atomicPerRPCCredentials struct {
+	atomic.Value
+}
+
+func (t *atomicPerRPCCredentials) Store(properties credentials.PerRPCCredentials) {
+	t.Value.Store(properties)
+}
+
+func (t *atomicPerRPCCredentials) Load() credentials.PerRPCCredentials {
+	val := t.Value.Load()
+	if val == nil {
+		return CustomHeaderTokenSource{}
+	}
+
+	return val.(credentials.PerRPCCredentials)
+}
+
+func newAtomicPerPRCCredentials() *atomicPerRPCCredentials {
+	return &atomicPerRPCCredentials{
+		Value: atomic.Value{},
+	}
+}
+
+// PerRPCCredentialsFuture is a future wrapper for credentials.PerRPCCredentials that can act as one and also be
+// materialized later.
+type PerRPCCredentialsFuture struct {
+	perRPCCredentials *atomicPerRPCCredentials
+	initialized       stdlibAtomic.Bool
+}
+
+// GetRequestMetadata gets the authorization metadata as a map using a TokenSource to generate a token
+func (ts *PerRPCCredentialsFuture) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	if ts.initialized.Load() {
+		tp := ts.perRPCCredentials.Load()
+		return tp.GetRequestMetadata(ctx, uri...)
+	}
+
+	return map[string]string{}, nil
+}
+
+// RequireTransportSecurity returns whether this credentials class requires TLS/SSL. OAuth uses Bearer tokens that are
+// susceptible to MITM (Man-In-The-Middle) attacks that are mitigated by TLS/SSL. We may return false here to make it
+// easier to setup auth. However, in a production environment, TLS for OAuth2 is a requirement.
+// see also: https://tools.ietf.org/html/rfc6749#section-3.1
+func (ts *PerRPCCredentialsFuture) RequireTransportSecurity() bool {
+	if ts.initialized.Load() {
+		return ts.perRPCCredentials.Load().RequireTransportSecurity()
+	}
+
+	return false
+}
+
+func (ts *PerRPCCredentialsFuture) Store(tokenSource credentials.PerRPCCredentials) {
+	ts.perRPCCredentials.Store(tokenSource)
+	ts.initialized.Store(true)
+}
+
+func (ts *PerRPCCredentialsFuture) Get() credentials.PerRPCCredentials {
+	return ts.perRPCCredentials.Load()
+}
+
+func (ts *PerRPCCredentialsFuture) IsInitialized() bool {
+	return ts.initialized.Load()
+}
+
+// NewPerRPCCredentialsFuture initializes a new PerRPCCredentialsFuture that can act as a credentials.PerRPCCredentials
+// and can also be resolved in the future. Users of the future can check if it has been initialized before by calling
+// PerRPCCredentialsFuture.IsInitialized(). Calling PerRPCCredentialsFuture.Get() multiple times will return
+// the same stored object (unless it changed in between calls). Calling PerRPCCredentialsFuture.Store() multiple
+// times is supported and will result in overriding the old value atomically.
+func NewPerRPCCredentialsFuture() *PerRPCCredentialsFuture {
+	tokenSource := PerRPCCredentialsFuture{
+		perRPCCredentials: newAtomicPerPRCCredentials(),
+	}
+
+	return &tokenSource
+}

--- a/clients/go/admin/atomic_credentials_test.go
+++ b/clients/go/admin/atomic_credentials_test.go
@@ -1,0 +1,57 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtomicPerRPCCredentials(t *testing.T) {
+	a := atomicPerRPCCredentials{}
+	assert.True(t, a.Load().RequireTransportSecurity())
+
+	tokenSource := DummyTestTokenSource{}
+	chTokenSource := NewCustomHeaderTokenSource(tokenSource, true, "my_custom_header")
+	a.Store(chTokenSource)
+
+	assert.False(t, a.Load().RequireTransportSecurity())
+}
+
+func TestNewPerRPCCredentialsFuture(t *testing.T) {
+	f := NewPerRPCCredentialsFuture()
+	assert.False(t, f.RequireTransportSecurity())
+	assert.Equal(t, CustomHeaderTokenSource{}, f.Get())
+
+	tokenSource := DummyTestTokenSource{}
+	chTokenSource := NewCustomHeaderTokenSource(tokenSource, false, "my_custom_header")
+	f.Store(chTokenSource)
+
+	assert.True(t, f.Get().RequireTransportSecurity())
+	assert.True(t, f.RequireTransportSecurity())
+}
+
+func ExampleNewPerRPCCredentialsFuture() {
+	f := NewPerRPCCredentialsFuture()
+
+	// Starts uninitialized
+	fmt.Println("Initialized:", f.IsInitialized())
+
+	// Implements credentials.PerRPCCredentials so can be used as one
+	m, err := f.GetRequestMetadata(context.TODO(), "")
+	fmt.Println("GetRequestMetadata:", m, "Error:", err)
+
+	// Materialize the value later and populate
+	tokenSource := DummyTestTokenSource{}
+	f.Store(NewCustomHeaderTokenSource(tokenSource, false, "my_custom_header"))
+
+	// Future calls to credentials.PerRPCCredentials methods will use the new instance
+	m, err = f.GetRequestMetadata(context.TODO(), "")
+	fmt.Println("GetRequestMetadata:", m, "Error:", err)
+
+	// Output:
+	// Initialized: false
+	// GetRequestMetadata: map[] Error: <nil>
+	// GetRequestMetadata: map[my_custom_header:Bearer abc] Error: <nil>
+}

--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -19,8 +19,6 @@ import (
 func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.TokenCache, perRPCCredentials *PerRPCCredentialsFuture) error {
 	authMetadataClient, err := InitializeAuthMetadataClient(ctx, cfg)
 	if err != nil {
-		// EngHabu: I don't know why did we use to panic here. Generally speaking, libraries should error on the side of
-		// 	returning errors instead.
 		return fmt.Errorf("failed to initialized Auth Metadata Client. Error: %w", err)
 	}
 

--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -1,0 +1,74 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flyteorg/flyteidl/clients/go/admin/cache"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
+	"github.com/flyteorg/flytestdlib/logger"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"google.golang.org/grpc"
+)
+
+// ResetTokenSource will attempt to build a TokenSource given the anonymously available information exposed by the server.
+// Once established, it'll invoke CustomHeaderTokenSource.Reset() on tokenSource to populate it with the appropriate values.
+func ResetTokenSource(ctx context.Context, cfg *Config, tokenCache cache.TokenCache, tokenSource *CustomHeaderTokenSource) error {
+	authMetadataClient, err := InitializeAuthMetadataClient(ctx, cfg)
+	if err != nil {
+		// EngHabu: I don't know why did we use to panic here. Generally speaking, libraries should error on the side of
+		// 	returning errors instead.
+		return fmt.Errorf("failed to initialize Auth Metadata Client. Error: %w", err)
+	}
+
+	tokenSourceProvider, err := NewTokenSourceProvider(ctx, cfg, tokenCache, authMetadataClient)
+	if err != nil {
+		return fmt.Errorf("failed to initialize token source provider. Err: %w", err)
+	}
+
+	clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch client metadata. Error: %v", err)
+	}
+
+	tSource, err := tokenSourceProvider.GetTokenSource(ctx)
+	if err != nil {
+		return err
+	}
+
+	tokenSource.Reset(tSource, clientMetadata.AuthorizationMetadataKey, cfg.UseInsecureConnection)
+	return nil
+}
+
+// newAuthInterceptor creates a new grpc.UnaryClientInterceptor that forwards the grpc call and inspects the error.
+// If an auth error is detected, it'll panic the process. This is useful for scenarios when auth is enabled after the client
+// has been up or if a client was inadvertently (due to transient network failures... etc.) built without auth credentials.
+// It will first invoke the grpc pipeline (to proceed with the request) with no modifications. It's expected for the grpc
+// pipeline to already have a grpc.WithPerRPCCredentials() DialOption. If the tokenSource has already been initialized,
+// it'll take care of refreshing when it expires... etc.
+// If the first invocation fails with an auth error, this interceptor will then attempt to establish a token source once
+// more. It'll fail hard if it couldn't do so (i.e. it will no longer attempt to send an unauthenticated request). Once
+// a token source has been created, it'll invoke the grpc pipeline again, this time the grpc.PerRPCCredentials should
+// be able to find and acquire a valid AccessToken to annotate the request with.
+func newAuthInterceptor(cfg *Config, tokenCache cache.TokenCache, tokenSource *CustomHeaderTokenSource) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if st, ok := status.FromError(err); ok {
+			// If the error we receive from executing the request expects
+			if st.Code() == codes.PermissionDenied || st.Code() == codes.Unauthenticated {
+				logger.Debugf(ctx, "Request failed due to [%v]. Attempting to establish an authenticated connection and trying again.", st.Code())
+				newErr := ResetTokenSource(ctx, cfg, tokenCache, tokenSource)
+				if newErr != nil {
+					return fmt.Errorf("authentication error! Original Error: %v, Auth Error: %w", err, newErr)
+				}
+
+				return invoker(ctx, method, req, reply, cc, opts...)
+			}
+		}
+
+		return err
+	}
+}

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -85,8 +85,8 @@ func (s *authMetadataServer) Start(_ context.Context) error {
 	grpcS := grpc.NewServer()
 	service2.RegisterAuthMetadataServiceServer(grpcS, s)
 	go func() {
-		err := grpcS.Serve(lis)
-		assert.NoError(s.t, err)
+		_ = grpcS.Serve(lis)
+		//assert.NoError(s.t, err)
 	}()
 
 	s.grpcServer = grpcS

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -1,0 +1,188 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	mocks2 "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
+	"github.com/stretchr/testify/mock"
+
+	service2 "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
+	"github.com/flyteorg/flytestdlib/config"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/flyteorg/flyteidl/clients/go/admin/cache/mocks"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const authServerPort = "50051"
+
+// authMetadataServer is a fake AuthMetadataServer that takes in an AuthMetadataServer implementation (usually one
+// initialized through mockery) and starts a local server that uses it to respond to grpc requests.
+type authMetadataServer struct {
+	s           *httptest.Server
+	t           testing.TB
+	grpcServer  *grpc.Server
+	netListener net.Listener
+	impl        service2.AuthMetadataServiceServer
+	lck         *sync.RWMutex
+}
+
+func (s authMetadataServer) GetOAuth2Metadata(ctx context.Context, in *service2.OAuth2MetadataRequest) (*service2.OAuth2MetadataResponse, error) {
+	return s.impl.GetOAuth2Metadata(ctx, in)
+}
+
+func (s authMetadataServer) GetPublicClientConfig(ctx context.Context, in *service2.PublicClientAuthConfigRequest) (*service2.PublicClientAuthConfigResponse, error) {
+	return s.impl.GetPublicClientConfig(ctx, in)
+}
+
+func (s authMetadataServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var issuer string
+	switch r.URL.Path {
+	case "/.well-known/oauth-authorization-server":
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, strings.ReplaceAll(`{
+				"issuer": "https://dev-14186422.okta.com",
+				"authorization_endpoint": "https://example.com/auth",
+				"token_endpoint": "https://example.com/token",
+				"jwks_uri": "https://example.com/keys",
+				"id_token_signing_alg_values_supported": ["RS256"]
+			}`, "ISSUER", issuer))
+		if !assert.NoError(s.t, err) {
+			s.t.FailNow()
+		}
+
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func (s *authMetadataServer) Start(_ context.Context) error {
+	s.lck.Lock()
+	defer s.lck.Unlock()
+
+	/***** Set up the server serving channelz service. *****/
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", authServerPort))
+	if err != nil {
+		return fmt.Errorf("failed to listen: %w", err)
+	}
+
+	grpcS := grpc.NewServer()
+	service2.RegisterAuthMetadataServiceServer(grpcS, s)
+	go func() {
+		err := grpcS.Serve(lis)
+		assert.NoError(s.t, err)
+	}()
+
+	s.grpcServer = grpcS
+	s.netListener = lis
+
+	s.s = httptest.NewServer(s)
+
+	return nil
+}
+
+func (s *authMetadataServer) Close() {
+	s.lck.RLock()
+	defer s.lck.RUnlock()
+
+	s.grpcServer.Stop()
+	s.s.Close()
+}
+
+func newAuthMetadataServer(t testing.TB, impl service2.AuthMetadataServiceServer) *authMetadataServer {
+	return &authMetadataServer{
+		t:    t,
+		impl: impl,
+		lck:  &sync.RWMutex{},
+	}
+}
+
+func Test_newAuthInterceptor(t *testing.T) {
+	t.Run("Other Error", func(t *testing.T) {
+		f := NewPerRPCCredentialsFuture()
+		interceptor := newAuthInterceptor(&Config{}, &mocks.TokenCache{}, f)
+		otherError := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return status.New(codes.Canceled, "").Err()
+		}
+
+		assert.Error(t, interceptor(context.Background(), "POST", nil, nil, nil, otherError))
+	})
+
+	t.Run("Unauthenticated first time, succeed", func(t *testing.T) {
+		m := &mocks2.AuthMetadataServiceServer{}
+		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{
+			AuthorizationEndpoint: fmt.Sprintf("http://localhost:%s/oauth2/authorize", authServerPort),
+			TokenEndpoint:         fmt.Sprintf("http://localhost:%s/oauth2/token", authServerPort),
+			JwksUri:               fmt.Sprintf("http://localhost:%s/oauth2/jwks", authServerPort),
+		}, nil)
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{
+			Scopes: []string{"all"},
+		}, nil)
+		s := newAuthMetadataServer(t, m)
+		ctx := context.Background()
+		assert.NoError(t, s.Start(ctx))
+		defer s.Close()
+
+		u, err := url.Parse("dns:///localhost:50051")
+		assert.NoError(t, err)
+
+		f := NewPerRPCCredentialsFuture()
+		interceptor := newAuthInterceptor(&Config{
+			Endpoint:              config.URL{URL: *u},
+			UseInsecureConnection: true,
+		}, &mocks.TokenCache{}, f)
+		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return status.New(codes.Unauthenticated, "").Err()
+		}
+
+		err = interceptor(ctx, "POST", nil, nil, nil, unauthenticated)
+		assert.Error(t, err)
+		assert.Truef(t, f.IsInitialized(), "PerRPCCredentialFuture should be initialized")
+		assert.False(t, f.Get().RequireTransportSecurity(), "Insecure should be true leading to RequireTLS false")
+	})
+
+	t.Run("Other error, doesn't authenticate", func(t *testing.T) {
+		m := &mocks2.AuthMetadataServiceServer{}
+		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{
+			AuthorizationEndpoint: fmt.Sprintf("http://localhost:%s/oauth2/authorize", authServerPort),
+			TokenEndpoint:         fmt.Sprintf("http://localhost:%s/oauth2/token", authServerPort),
+			JwksUri:               fmt.Sprintf("http://localhost:%s/oauth2/jwks", authServerPort),
+		}, nil)
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{
+			Scopes: []string{"all"},
+		}, nil)
+		s := newAuthMetadataServer(t, m)
+		ctx := context.Background()
+		assert.NoError(t, s.Start(ctx))
+		defer s.Close()
+
+		u, err := url.Parse("dns:///localhost:50051")
+		assert.NoError(t, err)
+
+		f := NewPerRPCCredentialsFuture()
+		interceptor := newAuthInterceptor(&Config{
+			Endpoint:              config.URL{URL: *u},
+			UseInsecureConnection: true,
+		}, &mocks.TokenCache{}, f)
+		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			return status.New(codes.Aborted, "").Err()
+		}
+
+		err = interceptor(ctx, "POST", nil, nil, nil, unauthenticated)
+		assert.Error(t, err)
+		assert.Falsef(t, f.IsInitialized(), "PerRPCCredentialFuture should not be initialized")
+	})
+}

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -143,6 +143,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		interceptor := newAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
+			AuthType:              AuthTypeClientSecret,
 		}, &mocks.TokenCache{}, f)
 		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Unauthenticated, "").Err()
@@ -164,6 +165,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{
 			Scopes: []string{"all"},
 		}, nil)
+
 		s := newAuthMetadataServer(t, m)
 		ctx := context.Background()
 		assert.NoError(t, s.Start(ctx))
@@ -176,6 +178,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		interceptor := newAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
+			AuthType:              AuthTypeClientSecret,
 		}, &mocks.TokenCache{}, f)
 		unauthenticated := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Aborted, "").Err()

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/flyteorg/flytestdlib/logger"
+
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	mocks2 "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
@@ -75,7 +77,7 @@ func (s *authMetadataServer) Start(_ context.Context) error {
 	defer s.lck.Unlock()
 
 	/***** Set up the server serving channelz service. *****/
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", s.port))
 	if err != nil {
 		return fmt.Errorf("failed to listen on port [%v]: %w", s.port, err)
 	}
@@ -124,6 +126,10 @@ func Test_newAuthInterceptor(t *testing.T) {
 	})
 
 	t.Run("Unauthenticated first time, succeed", func(t *testing.T) {
+		assert.NoError(t, logger.SetConfig(&logger.Config{
+			Level: logger.DebugLevel,
+		}))
+
 		port := rand.IntnRange(10000, 60000)
 		m := &mocks2.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{
@@ -159,6 +165,10 @@ func Test_newAuthInterceptor(t *testing.T) {
 	})
 
 	t.Run("Other error, doesn't authenticate", func(t *testing.T) {
+		assert.NoError(t, logger.SetConfig(&logger.Config{
+			Level: logger.DebugLevel,
+		}))
+
 		port := rand.IntnRange(10000, 60000)
 		m := &mocks2.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -319,7 +319,7 @@ func ExampleClientSetBuilder() {
 	// See AuthType for a list of supported authentication types.
 	clientSet, err := NewClientsetBuilder().WithConfig(GetConfig(ctx)).Build(ctx)
 	if err != nil {
-		logger.Fatalf(ctx, "failed to initialize clientSet from config. Error: %v", err)
+		logger.Fatalf(ctx, "failed to initialized clientSet from config. Error: %v", err)
 	}
 
 	// Access and use the desired client:

--- a/clients/go/admin/token_source.go
+++ b/clients/go/admin/token_source.go
@@ -2,8 +2,6 @@ package admin
 
 import (
 	"context"
-	"sync/atomic"
-
 	"golang.org/x/oauth2"
 )
 
@@ -11,91 +9,42 @@ import (
 // the credentials.PerRPCCredentials interface. This is because we want to be able to support a different 'header'
 // when passing the token in the gRPC call's metadata. The default is filled in in the constructor if none is supplied.
 type CustomHeaderTokenSource struct {
-	tokenProperties atomicTokenProperties
-}
-
-const DefaultAuthorizationHeader = "authorization"
-
-// tokenSourceProperties encapsulates properties needed by the TokenSource to set the token on the request.
-type tokenSourceProperties struct {
 	tokenSource  oauth2.TokenSource
 	customHeader string
 	insecure     bool
-	initialized  bool
 }
 
-// atomicTokenProperties provides a convenience on top of tokenSourceProperties to be thread-safe.
-type atomicTokenProperties struct {
-	atomic.Value
-}
-
-func (t *atomicTokenProperties) Store(properties tokenSourceProperties) {
-	t.Value.Store(properties)
-}
-
-func (t *atomicTokenProperties) Load() tokenSourceProperties {
-	val := t.Value.Load()
-	if val == nil {
-		return tokenSourceProperties{}
-	}
-
-	return val.(tokenSourceProperties)
-}
-
-// GetRequestMetadata gets the authorization metadata as a map using a TokenSource to generate a token
-func (ts *CustomHeaderTokenSource) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	tp := ts.tokenProperties.Load()
-	if !tp.initialized {
-		return map[string]string{}, nil
-	}
-
-	token, err := tp.tokenSource.Token()
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]string{
-		tp.customHeader: token.Type() + " " + token.AccessToken,
-	}, nil
-}
+const DefaultAuthorizationHeader = "authorization"
 
 // RequireTransportSecurity returns whether this credentials class requires TLS/SSL. OAuth uses Bearer tokens that are
 // susceptible to MITM (Man-In-The-Middle) attacks that are mitigated by TLS/SSL. We may return false here to make it
 // easier to setup auth. However, in a production environment, TLS for OAuth2 is a requirement.
 // see also: https://tools.ietf.org/html/rfc6749#section-3.1
-func (ts *CustomHeaderTokenSource) RequireTransportSecurity() bool {
-	tp := ts.tokenProperties.Load()
-	return tp.initialized && !tp.insecure
+func (ts CustomHeaderTokenSource) RequireTransportSecurity() bool {
+	return !ts.insecure
 }
 
-func NewCustomHeaderTokenSource(source oauth2.TokenSource, insecure bool, customHeader string) *CustomHeaderTokenSource {
-	tokenSource := NewDelayedCustomHeaderTokenSource()
-	tokenSource.Reset(source, customHeader, insecure)
-	return tokenSource
+// GetRequestMetadata gets the authorization metadata as a map using a TokenSource to generate a token
+func (ts CustomHeaderTokenSource) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	token, err := ts.tokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		ts.customHeader: token.Type() + " " + token.AccessToken,
+	}, nil
 }
 
-func (ts *CustomHeaderTokenSource) Reset(source oauth2.TokenSource, customHeader string, insecure bool) {
+func NewCustomHeaderTokenSource(source oauth2.TokenSource, insecure bool, customHeader string) CustomHeaderTokenSource {
 	header := DefaultAuthorizationHeader
 	if customHeader != "" {
 		header = customHeader
 	}
 
-	ts.tokenProperties.Store(tokenSourceProperties{
+	return CustomHeaderTokenSource{
 		tokenSource:  source,
 		customHeader: header,
 		insecure:     insecure,
-		initialized:  true,
-	})
-}
-
-func NewDelayedCustomHeaderTokenSource() *CustomHeaderTokenSource {
-	tp := atomicTokenProperties{
-		Value: atomic.Value{},
 	}
-
-	tokenSource := CustomHeaderTokenSource{
-		tokenProperties: tp,
-	}
-
-	return &tokenSource
 }

--- a/clients/go/admin/token_source.go
+++ b/clients/go/admin/token_source.go
@@ -2,29 +2,60 @@ package admin
 
 import (
 	"context"
+	"sync/atomic"
 
 	"golang.org/x/oauth2"
 )
 
-// This class is here because we cannot use the normal "github.com/grpc/grpc-go/credentials/oauth" package to satisfy
+// CustomHeaderTokenSource class is here because we cannot use the normal "github.com/grpc/grpc-go/credentials/oauth" package to satisfy
 // the credentials.PerRPCCredentials interface. This is because we want to be able to support a different 'header'
 // when passing the token in the gRPC call's metadata. The default is filled in in the constructor if none is supplied.
 type CustomHeaderTokenSource struct {
-	oauth2.TokenSource
-	customHeader string
-	insecure     bool
+	tokenProperties atomicTokenProperties
 }
 
 const DefaultAuthorizationHeader = "authorization"
 
+// tokenSourceProperties encapsulates properties needed by the TokenSource to set the token on the request.
+type tokenSourceProperties struct {
+	tokenSource  oauth2.TokenSource
+	customHeader string
+	insecure     bool
+	initialized  bool
+}
+
+// atomicTokenProperties provides a convenience on top of tokenSourceProperties to be thread-safe.
+type atomicTokenProperties struct {
+	atomic.Value
+}
+
+func (t *atomicTokenProperties) Store(properties tokenSourceProperties) {
+	t.Value.Store(properties)
+}
+
+func (t *atomicTokenProperties) Load() tokenSourceProperties {
+	val := t.Value.Load()
+	if val == nil {
+		return tokenSourceProperties{}
+	}
+
+	return val.(tokenSourceProperties)
+}
+
 // GetRequestMetadata gets the authorization metadata as a map using a TokenSource to generate a token
-func (ts CustomHeaderTokenSource) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	token, err := ts.Token()
+func (ts *CustomHeaderTokenSource) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	tp := ts.tokenProperties.Load()
+	if !tp.initialized {
+		return map[string]string{}, nil
+	}
+
+	token, err := tp.tokenSource.Token()
 	if err != nil {
 		return nil, err
 	}
+
 	return map[string]string{
-		ts.customHeader: token.Type() + " " + token.AccessToken,
+		tp.customHeader: token.Type() + " " + token.AccessToken,
 	}, nil
 }
 
@@ -32,19 +63,39 @@ func (ts CustomHeaderTokenSource) GetRequestMetadata(ctx context.Context, uri ..
 // susceptible to MITM (Man-In-The-Middle) attacks that are mitigated by TLS/SSL. We may return false here to make it
 // easier to setup auth. However, in a production environment, TLS for OAuth2 is a requirement.
 // see also: https://tools.ietf.org/html/rfc6749#section-3.1
-func (ts CustomHeaderTokenSource) RequireTransportSecurity() bool {
-	return !ts.insecure
+func (ts *CustomHeaderTokenSource) RequireTransportSecurity() bool {
+	tp := ts.tokenProperties.Load()
+	return tp.initialized && !tp.insecure
 }
 
-func NewCustomHeaderTokenSource(source oauth2.TokenSource, insecure bool, customHeader string) CustomHeaderTokenSource {
+func NewCustomHeaderTokenSource(source oauth2.TokenSource, insecure bool, customHeader string) *CustomHeaderTokenSource {
+	tokenSource := NewDelayedCustomHeaderTokenSource()
+	tokenSource.Reset(source, customHeader, insecure)
+	return tokenSource
+}
+
+func (ts *CustomHeaderTokenSource) Reset(source oauth2.TokenSource, customHeader string, insecure bool) {
 	header := DefaultAuthorizationHeader
 	if customHeader != "" {
 		header = customHeader
 	}
 
-	return CustomHeaderTokenSource{
-		TokenSource:  source,
+	ts.tokenProperties.Store(tokenSourceProperties{
+		tokenSource:  source,
 		customHeader: header,
 		insecure:     insecure,
+		initialized:  true,
+	})
+}
+
+func NewDelayedCustomHeaderTokenSource() *CustomHeaderTokenSource {
+	tp := atomicTokenProperties{
+		Value: atomic.Value{},
 	}
+
+	tokenSource := CustomHeaderTokenSource{
+		tokenProperties: tp,
+	}
+
+	return &tokenSource
 }

--- a/clients/go/admin/token_source.go
+++ b/clients/go/admin/token_source.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+
 	"golang.org/x/oauth2"
 )
 


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Change client auth mechanism to attempt to build a TokenSource whenever any client call received the equivalent of http 401 UNAUTHORIZED response code.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Existing mechanism to build an authenticated client depends on auth negotiation at the very first time the gRPC client connection is built. If at the time:
1. Auth hasn't been enabled on admin, or
2. It fails to query for Auth endpoints for any transient network reasons.
It'll fallback to assuming Auth isn't enabled on the server and build an unauthenticated gRPC client. Once that's built, it's reused for the entirety of the lifetime of the process.
If auth is enabled (or config changed) at a later point, all existing clients will fail to authenticate and never recover.

With this change, it establishes a better pattern akin to the HTTP-recognized behavior of responding to auth code failures by attempting to authenticate.

After the change, the client will always be built unauthenticated, as soon as the first request is sent and receives an authentication error, it'll attempt to negotiate auth and build a valid token source.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/2841
