### PR TITLE
Update pinned googleapis buf package

### DIFF
--- a/protos/buf.lock
+++ b/protos/buf.lock
@@ -4,14 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 2aa0ce062bf84656ad01d979d5c64038
-    digest: b1-m2miB5uR65x_C-ImFfVIHaeVmyd1u5X7NugZ2vDbpJI=
-    create_time: 2022-06-01T15:05:55.95283Z
+    commit: 62f35d8aed1149c291d606d958a7ce32
   - remote: buf.build
     owner: unionai
     repository: protoc-gen-swagger
-    branch: main
-    commit: 560c4f34581045c4a4e59ffab94fceb0
-    digest: b1-eoEUXiWuST4tiiorwcO2Nvx_1pX0GHqRjUlc3sQocig=
-    create_time: 2022-06-02T06:14:15.441008Z
+    commit: fd9d94dc48154d5c94ccc43695df150f

--- a/protos/buf.yaml
+++ b/protos/buf.yaml
@@ -7,5 +7,5 @@ breaking:
   use:
     - FILE
 deps:
-  - buf.build/googleapis/googleapis
+  - buf.build/googleapis/googleapis:62f35d8aed1149c291d606d958a7ce32
   - buf.build/unionai/protoc-gen-swagger


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Context: https://docs.buf.build/faq#googleapis-failure

Buf recently repackaged the googleapis to a core set of imports to reduce the size of the total package.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Buf generate can fail with

```
https://github.com/googleapis/googleapis contains over 3800 files, mostly
relating to Google's core APIs. However, there are only ~30 files used by
99.999% of developers, and these files are the most common dependency in
the Protobuf ecosystem. This hosted module now only includes these specific
files, as including all the files causes hundreds of megabytes of unused
generated code for the vast majority of developers.

Before taking the BSR out of beta, we slimmed down googleapis from the ~3800
files to these common ~30 files. Having all ~3800 files caused many
issues for our consumers, with no benefit. Considering this, we made the
decision to trim down the module so we can ensure the best experience for our
users as we finalize v1.
```

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
