### PR TITLE
Expose newAuthInterceptor to allow clients to create authenticated connections

### DIFF
--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -46,7 +46,7 @@ func shouldAttemptToAuthenticate(errorCode codes.Code) bool {
 	return errorCode == codes.Unauthenticated
 }
 
-// newAuthInterceptor creates a new grpc.UnaryClientInterceptor that forwards the grpc call and inspects the error.
+// NewAuthInterceptor creates a new grpc.UnaryClientInterceptor that forwards the grpc call and inspects the error.
 // It will first invoke the grpc pipeline (to proceed with the request) with no modifications. It's expected for the grpc
 // pipeline to already have a grpc.WithPerRPCCredentials() DialOption. If the perRPCCredentials has already been initialized,
 // it'll take care of refreshing when tokens expire... etc.
@@ -56,7 +56,7 @@ func shouldAttemptToAuthenticate(errorCode codes.Code) bool {
 // more. It'll fail hard if it couldn't do so (i.e. it will no longer attempt to send an unauthenticated request). Once
 // a token source has been created, it'll invoke the grpc pipeline again, this time the grpc.PerRPCCredentials should
 // be able to find and acquire a valid AccessToken to annotate the request with.
-func newAuthInterceptor(cfg *Config, tokenCache cache.TokenCache, credentialsFuture *PerRPCCredentialsFuture) grpc.UnaryClientInterceptor {
+func NewAuthInterceptor(cfg *Config, tokenCache cache.TokenCache, credentialsFuture *PerRPCCredentialsFuture) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err != nil {

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -117,7 +117,7 @@ func newAuthMetadataServer(t testing.TB, port int, impl service2.AuthMetadataSer
 func Test_newAuthInterceptor(t *testing.T) {
 	t.Run("Other Error", func(t *testing.T) {
 		f := NewPerRPCCredentialsFuture()
-		interceptor := newAuthInterceptor(&Config{}, &mocks.TokenCache{}, f)
+		interceptor := NewAuthInterceptor(&Config{}, &mocks.TokenCache{}, f)
 		otherError := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return status.New(codes.Canceled, "").Err()
 		}
@@ -149,7 +149,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		interceptor := newAuthInterceptor(&Config{
+		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
@@ -180,7 +180,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		interceptor := newAuthInterceptor(&Config{
+		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,
@@ -219,7 +219,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		assert.NoError(t, err)
 
 		f := NewPerRPCCredentialsFuture()
-		interceptor := newAuthInterceptor(&Config{
+		interceptor := NewAuthInterceptor(&Config{
 			Endpoint:              config.URL{URL: *u},
 			UseInsecureConnection: true,
 			AuthType:              AuthTypeClientSecret,

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -164,7 +164,7 @@ func InitializeAdminClient(ctx context.Context, cfg *Config, opts ...grpc.DialOp
 func initializeClients(ctx context.Context, cfg *Config, tokenCache cache.TokenCache, opts ...grpc.DialOption) (*Clientset, error) {
 	credentialsFuture := NewPerRPCCredentialsFuture()
 	opts = append(opts,
-		grpc.WithChainUnaryInterceptor(newAuthInterceptor(cfg, tokenCache, credentialsFuture)),
+		grpc.WithChainUnaryInterceptor(NewAuthInterceptor(cfg, tokenCache, credentialsFuture)),
 		grpc.WithPerRPCCredentials(credentialsFuture))
 
 	if cfg.DefaultServiceConfig != "" {


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Expose NewAuthInterceptor function publicly to allow callers to create grpcConnections that authenticate to remote services using the same auth challenge/handshake used when building FlyteAdmin client.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

