### PR TITLE
Make call to auth metadata optional

### DIFF
--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -27,9 +27,13 @@ func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.T
 		return fmt.Errorf("failed to initialized token source provider. Err: %w", err)
 	}
 
-	clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch client metadata. Error: %v", err)
+	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	if len(authorizationMetadataKey) == 0 {
+		clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
+		if err != nil {
+			return fmt.Errorf("failed to fetch client metadata. Error: %v", err)
+		}
+		authorizationMetadataKey = clientMetadata.AuthorizationMetadataKey
 	}
 
 	tokenSource, err := tokenSourceProvider.GetTokenSource(ctx)
@@ -37,7 +41,7 @@ func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.T
 		return err
 	}
 
-	wrappedTokenSource := NewCustomHeaderTokenSource(tokenSource, cfg.UseInsecureConnection, clientMetadata.AuthorizationMetadataKey)
+	wrappedTokenSource := NewCustomHeaderTokenSource(tokenSource, cfg.UseInsecureConnection, authorizationMetadataKey)
 	perRPCCredentials.Store(wrappedTokenSource)
 	return nil
 }

--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -27,7 +27,7 @@ func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.T
 		return fmt.Errorf("failed to initialized token source provider. Err: %w", err)
 	}
 
-	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	authorizationMetadataKey := cfg.AuthorizationHeader
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -28,6 +28,7 @@ func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.T
 	}
 
 	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	logger.Infof(ctx, "in auth interceptor, cfg.AuthorizationMetadataKey: %s", cfg.AuthorizationMetadataKey)
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/auth_interceptor.go
+++ b/clients/go/admin/auth_interceptor.go
@@ -28,7 +28,6 @@ func MaterializeCredentials(ctx context.Context, cfg *Config, tokenCache cache.T
 	}
 
 	authorizationMetadataKey := cfg.AuthorizationMetadataKey
-	logger.Infof(ctx, "in auth interceptor, cfg.AuthorizationMetadataKey: %s", cfg.AuthorizationMetadataKey)
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authMetadataClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -231,5 +232,32 @@ func Test_newAuthInterceptor(t *testing.T) {
 		err = interceptor(ctx, "POST", nil, nil, nil, unauthenticated)
 		assert.Error(t, err)
 		assert.Falsef(t, f.IsInitialized(), "PerRPCCredentialFuture should not be initialized")
+	})
+}
+
+func TestMaterializeCredentials(t *testing.T) {
+	t.Run("No public client config or oauth2 metadata endpoint lookup", func(t *testing.T) {
+		port := rand.IntnRange(10000, 60000)
+		m := &mocks2.AuthMetadataServiceServer{}
+		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get public client config"))
+		s := newAuthMetadataServer(t, port, m)
+		ctx := context.Background()
+		assert.NoError(t, s.Start(ctx))
+		defer s.Close()
+
+		u, err := url.Parse(fmt.Sprintf("dns:///localhost:%d", port))
+		assert.NoError(t, err)
+
+		f := NewPerRPCCredentialsFuture()
+		err = MaterializeCredentials(ctx, &Config{
+			Endpoint:              config.URL{URL: *u},
+			UseInsecureConnection: true,
+			AuthType:              AuthTypeClientSecret,
+			TokenURL:              fmt.Sprintf("http://localhost:%d/api/v1/token", port),
+			Scopes:                []string{"all"},
+			AuthorizationHeader:   "authorization",
+		}, &mocks.TokenCache{}, f)
+		assert.NoError(t, err)
 	})
 }

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -86,9 +86,13 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 		return nil, errors.New("can't create authenticated channel without a TokenSourceProvider")
 	}
 
-	clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch client metadata. Error: %v", err)
+	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	if len(authorizationMetadataKey) == 0 {
+		clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch client metadata. Error: %v", err)
+		}
+		authorizationMetadataKey = clientMetadata.AuthorizationMetadataKey
 	}
 
 	tokenSource, err := tokenSourceProvider.GetTokenSource(ctx)
@@ -96,7 +100,7 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 		return nil, err
 	}
 
-	wrappedTokenSource := NewCustomHeaderTokenSource(tokenSource, cfg.UseInsecureConnection, clientMetadata.AuthorizationMetadataKey)
+	wrappedTokenSource := NewCustomHeaderTokenSource(tokenSource, cfg.UseInsecureConnection, authorizationMetadataKey)
 	return grpc.WithPerRPCCredentials(wrappedTokenSource), nil
 }
 

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -87,6 +87,7 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 	}
 
 	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	logger.Infof(ctx, "in admin client, cfg.AuthorizationMetadataKey: %s", cfg.AuthorizationMetadataKey)
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -87,7 +87,6 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 	}
 
 	authorizationMetadataKey := cfg.AuthorizationMetadataKey
-	logger.Infof(ctx, "in admin client, cfg.AuthorizationMetadataKey: %s", cfg.AuthorizationMetadataKey)
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/client.go
+++ b/clients/go/admin/client.go
@@ -86,7 +86,7 @@ func getAuthenticationDialOption(ctx context.Context, cfg *Config, tokenSourcePr
 		return nil, errors.New("can't create authenticated channel without a TokenSourceProvider")
 	}
 
-	authorizationMetadataKey := cfg.AuthorizationMetadataKey
+	authorizationMetadataKey := cfg.AuthorizationHeader
 	if len(authorizationMetadataKey) == 0 {
 		clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 		if err != nil {

--- a/clients/go/admin/client_test.go
+++ b/clients/go/admin/client_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
@@ -132,6 +134,20 @@ func TestGetAuthenticationDialOptionClientSecret(t *testing.T) {
 		mockAuthClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(metatdata, nil)
 		mockAuthClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(clientMetatadata, nil)
 		dialOption, err := getAuthenticationDialOption(ctx, adminServiceConfig, nil, mockAuthClient)
+		assert.Nil(t, dialOption)
+		assert.NotNil(t, err)
+	})
+	t.Run("legal-no-external-calls", func(t *testing.T) {
+		mockAuthClient := new(mocks.AuthMetadataServiceClient)
+		mockAuthClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
+		mockAuthClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get public client config"))
+		var adminCfg Config
+		err := copier.Copy(&adminCfg, adminServiceConfig)
+		assert.NoError(t, err)
+		adminCfg.TokenURL = "http://localhost:1000/api/v1/token"
+		adminCfg.Scopes = []string{"all"}
+		adminCfg.AuthorizationHeader = "authorization"
+		dialOption, err := getAuthenticationDialOption(ctx, &adminCfg, nil, mockAuthClient)
 		assert.Nil(t, dialOption)
 		assert.NotNil(t, err)
 	})

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -78,6 +78,10 @@ type Config struct {
 	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625
 	// Note that required packages may need to be preloaded to support certain service config. For example "google.golang.org/grpc/balancer/roundrobin" should be preloaded to have round-robin policy supported.
 	DefaultServiceConfig string `json:"defaultServiceConfig" pdflag:",Set the default service config for the admin gRPC client"`
+
+	// Authorization Header to use when passing Access Tokens to the server. If not provided, the client should use the
+	// value returned by the PublicClientConfig
+	AuthorizationMetadataKey string `json:"authorizationMetadataKey" pflag:",Authorization Header to use when passing Access Tokens to the server"`
 }
 
 var (

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -64,8 +64,7 @@ type Config struct {
 	// See the implementation of the 'grpcAuthorizationHeader' option in Flyte Admin for more information. But
 	// basically we want to be able to use a different string to pass the token from this client to the the Admin service
 	// because things might be running in a service mesh (like Envoy) that already uses the default 'authorization' header
-	// Deprecated: It will automatically be discovered through an anonymously accessible auth metadata service.
-	DeprecatedAuthorizationHeader string `json:"authorizationHeader" pflag:",Custom metadata header to pass JWT"`
+	AuthorizationHeader string `json:"authorizationHeader" pflag:",Custom metadata header to pass JWT"`
 
 	PkceConfig pkce.Config `json:"pkceConfig" pflag:",Config for Pkce authentication flow."`
 
@@ -78,10 +77,6 @@ type Config struct {
 	// find the full schema here https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L625
 	// Note that required packages may need to be preloaded to support certain service config. For example "google.golang.org/grpc/balancer/roundrobin" should be preloaded to have round-robin policy supported.
 	DefaultServiceConfig string `json:"defaultServiceConfig" pdflag:",Set the default service config for the admin gRPC client"`
-
-	// Authorization Header to use when passing Access Tokens to the server. If not provided, the client should use the
-	// value returned by the PublicClientConfig
-	AuthorizationMetadataKey string `json:"authorizationMetadataKey" pflag:",Authorization Header to use when passing Access Tokens to the server"`
 }
 
 var (

--- a/clients/go/admin/config_flags.go
+++ b/clients/go/admin/config_flags.go
@@ -74,5 +74,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "deviceFlowConfig.pollInterval"), defaultConfig.DeviceFlowConfig.PollInterval.String(), "amount of time the device flow would poll the token endpoint if auth server doesn't return a polling interval. Okta and google IDP do return an interval'")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "command"), defaultConfig.Command, "Command for external authentication token generation")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultServiceConfig"), defaultConfig.DefaultServiceConfig, "")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationMetadataKey"), defaultConfig.AuthorizationMetadataKey, "Authorization Header to use when passing Access Tokens to the server")
 	return cmdFlags
 }

--- a/clients/go/admin/config_flags.go
+++ b/clients/go/admin/config_flags.go
@@ -66,7 +66,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "scopes"), defaultConfig.Scopes, "List of scopes to request")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationServerUrl"), defaultConfig.DeprecatedAuthorizationServerURL, "This is the URL to your IdP's authorization server. It'll default to Endpoint")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "tokenUrl"), defaultConfig.TokenURL, "OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationHeader"), defaultConfig.DeprecatedAuthorizationHeader, "Custom metadata header to pass JWT")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationHeader"), defaultConfig.AuthorizationHeader, "Custom metadata header to pass JWT")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "pkceConfig.timeout"), defaultConfig.PkceConfig.BrowserSessionTimeout.String(), "Amount of time the browser session would be active for authentication from client app.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "pkceConfig.refreshTime"), defaultConfig.PkceConfig.TokenRefreshGracePeriod.String(), "grace period from the token expiry after which it would refresh the token.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "deviceFlowConfig.refreshTime"), defaultConfig.DeviceFlowConfig.TokenRefreshGracePeriod.String(), "grace period from the token expiry after which it would refresh the token.")
@@ -74,6 +74,5 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "deviceFlowConfig.pollInterval"), defaultConfig.DeviceFlowConfig.PollInterval.String(), "amount of time the device flow would poll the token endpoint if auth server doesn't return a polling interval. Okta and google IDP do return an interval'")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "command"), defaultConfig.Command, "Command for external authentication token generation")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultServiceConfig"), defaultConfig.DefaultServiceConfig, "")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationMetadataKey"), defaultConfig.AuthorizationMetadataKey, "Authorization Header to use when passing Access Tokens to the server")
 	return cmdFlags
 }

--- a/clients/go/admin/config_flags_test.go
+++ b/clients/go/admin/config_flags_test.go
@@ -435,4 +435,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_authorizationMetadataKey", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("authorizationMetadataKey", testValue)
+			if vString, err := cmdFlags.GetString("authorizationMetadataKey"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.AuthorizationMetadataKey)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/clients/go/admin/config_flags_test.go
+++ b/clients/go/admin/config_flags_test.go
@@ -330,7 +330,7 @@ func TestConfig_SetFlags(t *testing.T) {
 
 			cmdFlags.Set("authorizationHeader", testValue)
 			if vString, err := cmdFlags.GetString("authorizationHeader"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DeprecatedAuthorizationHeader)
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.AuthorizationHeader)
 
 			} else {
 				assert.FailNow(t, err.Error())
@@ -429,20 +429,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			cmdFlags.Set("defaultServiceConfig", testValue)
 			if vString, err := cmdFlags.GetString("defaultServiceConfig"); err == nil {
 				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultServiceConfig)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
-	t.Run("Test_authorizationMetadataKey", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("authorizationMetadataKey", testValue)
-			if vString, err := cmdFlags.GetString("authorizationMetadataKey"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.AuthorizationMetadataKey)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/clients/go/admin/integration_test.go
+++ b/clients/go/admin/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package admin

--- a/clients/go/admin/integration_test.go
+++ b/clients/go/admin/integration_test.go
@@ -32,7 +32,7 @@ func TestLiveAdminClient(t *testing.T) {
 		ClientSecretLocation:             "/Users/username/.ssh/admin/propeller_secret",
 		DeprecatedAuthorizationServerURL: "https://lyft.okta.com/oauth2/ausc5wmjw96cRKvTd1t7",
 		Scopes:                           []string{"svc"},
-		DeprecatedAuthorizationHeader:    "Flyte-Authorization",
+		AuthorizationHeader:              "Flyte-Authorization",
 	})
 
 	resp, err := client.ListProjects(ctx, &admin.ProjectListRequest{})

--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -46,7 +46,6 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 		}
 
 		scopes := cfg.Scopes
-		logger.Infof(ctx, "in token source provider, cfg.Scopes: %s", cfg.Scopes)
 		if len(scopes) == 0 {
 			clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 			if err != nil {

--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -46,6 +46,7 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 		}
 
 		scopes := cfg.Scopes
+		logger.Infof(ctx, "in token source provider, cfg.Scopes: %s", cfg.Scopes)
 		if len(scopes) == 0 {
 			clientMetadata, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.3/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
The token source provider can optionally be configured with a default authorization metadata key that isn't discovered from the public client config.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2957

## Follow-up issue
_NA_

