### PR TITLE
Adding configurable audience property for flyte clients

### DIFF
--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -13,24 +13,18 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/flyteorg/flytestdlib/logger"
-
-	"k8s.io/apimachinery/pkg/util/rand"
-
-	"github.com/stretchr/testify/mock"
-
-	mocks2 "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
-
-	service2 "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
-	"github.com/flyteorg/flytestdlib/config"
-
 	"github.com/stretchr/testify/assert"
-
+	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/flyteorg/flyteidl/clients/go/admin/cache/mocks"
+	adminMocks "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
+	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flytestdlib/logger"
 )
 
 // authMetadataServer is a fake AuthMetadataServer that takes in an AuthMetadataServer implementation (usually one
@@ -41,15 +35,15 @@ type authMetadataServer struct {
 	port        int
 	grpcServer  *grpc.Server
 	netListener net.Listener
-	impl        service2.AuthMetadataServiceServer
+	impl        service.AuthMetadataServiceServer
 	lck         *sync.RWMutex
 }
 
-func (s authMetadataServer) GetOAuth2Metadata(ctx context.Context, in *service2.OAuth2MetadataRequest) (*service2.OAuth2MetadataResponse, error) {
+func (s authMetadataServer) GetOAuth2Metadata(ctx context.Context, in *service.OAuth2MetadataRequest) (*service.OAuth2MetadataResponse, error) {
 	return s.impl.GetOAuth2Metadata(ctx, in)
 }
 
-func (s authMetadataServer) GetPublicClientConfig(ctx context.Context, in *service2.PublicClientAuthConfigRequest) (*service2.PublicClientAuthConfigResponse, error) {
+func (s authMetadataServer) GetPublicClientConfig(ctx context.Context, in *service.PublicClientAuthConfigRequest) (*service.PublicClientAuthConfigResponse, error) {
 	return s.impl.GetPublicClientConfig(ctx, in)
 }
 
@@ -86,7 +80,7 @@ func (s *authMetadataServer) Start(_ context.Context) error {
 	}
 
 	grpcS := grpc.NewServer()
-	service2.RegisterAuthMetadataServiceServer(grpcS, s)
+	service.RegisterAuthMetadataServiceServer(grpcS, s)
 	go func() {
 		_ = grpcS.Serve(lis)
 		//assert.NoError(s.t, err)
@@ -108,7 +102,7 @@ func (s *authMetadataServer) Close() {
 	s.s.Close()
 }
 
-func newAuthMetadataServer(t testing.TB, port int, impl service2.AuthMetadataServiceServer) *authMetadataServer {
+func newAuthMetadataServer(t testing.TB, port int, impl service.AuthMetadataServiceServer) *authMetadataServer {
 	return &authMetadataServer{
 		port: port,
 		t:    t,
@@ -134,13 +128,13 @@ func Test_newAuthInterceptor(t *testing.T) {
 		}))
 
 		port := rand.IntnRange(10000, 60000)
-		m := &mocks2.AuthMetadataServiceServer{}
-		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{
+		m := &adminMocks.AuthMetadataServiceServer{}
+		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{
 			AuthorizationEndpoint: fmt.Sprintf("http://localhost:%d/oauth2/authorize", port),
 			TokenEndpoint:         fmt.Sprintf("http://localhost:%d/oauth2/token", port),
 			JwksUri:               fmt.Sprintf("http://localhost:%d/oauth2/jwks", port),
 		}, nil)
-		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{
 			Scopes: []string{"all"},
 		}, nil)
 		s := newAuthMetadataServer(t, port, m)
@@ -173,7 +167,7 @@ func Test_newAuthInterceptor(t *testing.T) {
 		}))
 
 		port := rand.IntnRange(10000, 60000)
-		m := &mocks2.AuthMetadataServiceServer{}
+		m := &adminMocks.AuthMetadataServiceServer{}
 		s := newAuthMetadataServer(t, port, m)
 		ctx := context.Background()
 		assert.NoError(t, s.Start(ctx))
@@ -203,13 +197,13 @@ func Test_newAuthInterceptor(t *testing.T) {
 		}))
 
 		port := rand.IntnRange(10000, 60000)
-		m := &mocks2.AuthMetadataServiceServer{}
-		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service2.OAuth2MetadataResponse{
+		m := &adminMocks.AuthMetadataServiceServer{}
+		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{
 			AuthorizationEndpoint: fmt.Sprintf("http://localhost:%d/oauth2/authorize", port),
 			TokenEndpoint:         fmt.Sprintf("http://localhost:%d/oauth2/token", port),
 			JwksUri:               fmt.Sprintf("http://localhost:%d/oauth2/jwks", port),
 		}, nil)
-		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{
 			Scopes: []string{"all"},
 		}, nil)
 
@@ -240,9 +234,9 @@ func Test_newAuthInterceptor(t *testing.T) {
 func TestMaterializeCredentials(t *testing.T) {
 	port := rand.IntnRange(10000, 60000)
 	t.Run("No oauth2 metadata endpoint lookup", func(t *testing.T) {
-		m := &mocks2.AuthMetadataServiceServer{}
+		m := &adminMocks.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
-		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{}, nil)
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{}, nil)
 		s := newAuthMetadataServer(t, port, m)
 		ctx := context.Background()
 		assert.NoError(t, s.Start(ctx))
@@ -263,7 +257,7 @@ func TestMaterializeCredentials(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("Failed to fetch client metadata", func(t *testing.T) {
-		m := &mocks2.AuthMetadataServiceServer{}
+		m := &adminMocks.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
 		failedPublicClientConfigLookup := errors.New("expected err")
 		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(nil, failedPublicClientConfigLookup)

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -17,18 +17,20 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	mocks2 "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
 	"github.com/stretchr/testify/mock"
+
+	mocks2 "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
 
 	service2 "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
 	"github.com/flyteorg/flytestdlib/config"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/flyteorg/flyteidl/clients/go/admin/cache/mocks"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/flyteorg/flyteidl/clients/go/admin/cache/mocks"
 )
 
 // authMetadataServer is a fake AuthMetadataServer that takes in an AuthMetadataServer implementation (usually one
@@ -281,6 +283,6 @@ func TestMaterializeCredentials(t *testing.T) {
 			TokenURL:              fmt.Sprintf("http://localhost:%d/api/v1/token", port),
 			Scopes:                []string{"all"},
 		}, &mocks.TokenCache{}, f)
-		assert.EqualError(t, err, "failed to fetch client metadata. Error: rpc error: code = Unknown desc = expected err")
+		assert.EqualError(t, err, "failed to initialized token source provider. Err: failed to fetch client metadata. Error: rpc error: code = Unknown desc = expected err")
 	})
 }

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -233,10 +233,10 @@ func Test_newAuthInterceptor(t *testing.T) {
 
 func TestMaterializeCredentials(t *testing.T) {
 	port := rand.IntnRange(10000, 60000)
-	t.Run("No oauth2 metadata endpoint lookup", func(t *testing.T) {
+	t.Run("No oauth2 metadata endpoint or Public client config lookup", func(t *testing.T) {
 		m := &adminMocks.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
-		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{}, nil)
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get public client config"))
 		s := newAuthMetadataServer(t, port, m)
 		ctx := context.Background()
 		assert.NoError(t, s.Start(ctx))
@@ -252,6 +252,7 @@ func TestMaterializeCredentials(t *testing.T) {
 			AuthType:              AuthTypeClientSecret,
 			TokenURL:              fmt.Sprintf("http://localhost:%d/api/v1/token", port),
 			Scopes:                []string{"all"},
+			Audience:              "http://localhost:30081",
 			AuthorizationHeader:   "authorization",
 		}, &mocks.TokenCache{}, f)
 		assert.NoError(t, err)

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -239,10 +239,10 @@ func Test_newAuthInterceptor(t *testing.T) {
 
 func TestMaterializeCredentials(t *testing.T) {
 	port := rand.IntnRange(10000, 60000)
-	t.Run("No public client config or oauth2 metadata endpoint lookup", func(t *testing.T) {
+	t.Run("No oauth2 metadata endpoint lookup", func(t *testing.T) {
 		m := &mocks2.AuthMetadataServiceServer{}
 		m.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get oauth2 metadata"))
-		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(nil, errors.New("unexpected call to get public client config"))
+		m.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service2.PublicClientAuthConfigResponse{}, nil)
 		s := newAuthMetadataServer(t, port, m)
 		ctx := context.Background()
 		assert.NoError(t, s.Start(ctx))

--- a/clients/go/admin/auth_interceptor_test.go
+++ b/clients/go/admin/auth_interceptor_test.go
@@ -278,6 +278,6 @@ func TestMaterializeCredentials(t *testing.T) {
 			TokenURL:              fmt.Sprintf("http://localhost:%d/api/v1/token", port),
 			Scopes:                []string{"all"},
 		}, &mocks.TokenCache{}, f)
-		assert.EqualError(t, err, "failed to initialized token source provider. Err: failed to fetch client metadata. Error: rpc error: code = Unknown desc = expected err")
+		assert.EqualError(t, err, "failed to fetch client metadata. Error: rpc error: code = Unknown desc = expected err")
 	})
 }

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	ClientSecretLocation string   `json:"clientSecretLocation" pflag:",File containing the client secret"`
 	ClientSecretEnvVar   string   `json:"clientSecretEnvVar" pflag:",Environment variable containing the client secret"`
 	Scopes               []string `json:"scopes" pflag:",List of scopes to request"`
+	Audience             string   `json:"audience" pflag:",Audience to use when initiating OAuth2 authorization requests."`
 
 	// There are two ways to get the token URL. If the authorization server url is provided, the client will try to use RFC 8414 to
 	// try to get the token URL. Or it can be specified directly through TokenURL config.

--- a/clients/go/admin/config.go
+++ b/clients/go/admin/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	ClientSecretLocation string   `json:"clientSecretLocation" pflag:",File containing the client secret"`
 	ClientSecretEnvVar   string   `json:"clientSecretEnvVar" pflag:",Environment variable containing the client secret"`
 	Scopes               []string `json:"scopes" pflag:",List of scopes to request"`
+	UseAudienceFromAdmin bool     `json:"useAudienceFromAdmin" pflag:",Use Audience configured from admins public endpoint config."`
 	Audience             string   `json:"audience" pflag:",Audience to use when initiating OAuth2 authorization requests."`
 
 	// There are two ways to get the token URL. If the authorization server url is provided, the client will try to use RFC 8414 to

--- a/clients/go/admin/config_flags.go
+++ b/clients/go/admin/config_flags.go
@@ -64,6 +64,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "clientSecretLocation"), defaultConfig.ClientSecretLocation, "File containing the client secret")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "clientSecretEnvVar"), defaultConfig.ClientSecretEnvVar, "Environment variable containing the client secret")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "scopes"), defaultConfig.Scopes, "List of scopes to request")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "useAudienceFromAdmin"), defaultConfig.UseAudienceFromAdmin, "Use Audience configured from admins public endpoint config.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "audience"), defaultConfig.Audience, "Audience to use when initiating OAuth2 authorization requests.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationServerUrl"), defaultConfig.DeprecatedAuthorizationServerURL, "This is the URL to your IdP's authorization server. It'll default to Endpoint")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "tokenUrl"), defaultConfig.TokenURL, "OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.")

--- a/clients/go/admin/config_flags.go
+++ b/clients/go/admin/config_flags.go
@@ -64,6 +64,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "clientSecretLocation"), defaultConfig.ClientSecretLocation, "File containing the client secret")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "clientSecretEnvVar"), defaultConfig.ClientSecretEnvVar, "Environment variable containing the client secret")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "scopes"), defaultConfig.Scopes, "List of scopes to request")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "audience"), defaultConfig.Audience, "Audience to use when initiating OAuth2 authorization requests.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationServerUrl"), defaultConfig.DeprecatedAuthorizationServerURL, "This is the URL to your IdP's authorization server. It'll default to Endpoint")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "tokenUrl"), defaultConfig.TokenURL, "OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "authorizationHeader"), defaultConfig.AuthorizationHeader, "Custom metadata header to pass JWT")

--- a/clients/go/admin/config_flags_test.go
+++ b/clients/go/admin/config_flags_test.go
@@ -295,6 +295,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_useAudienceFromAdmin", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("useAudienceFromAdmin", testValue)
+			if vBool, err := cmdFlags.GetBool("useAudienceFromAdmin"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.UseAudienceFromAdmin)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_audience", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/clients/go/admin/config_flags_test.go
+++ b/clients/go/admin/config_flags_test.go
@@ -295,6 +295,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_audience", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("audience", testValue)
+			if vString, err := cmdFlags.GetString("audience"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Audience)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_authorizationServerUrl", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -53,7 +53,7 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 		scopes := cfg.Scopes
 		audienceValue := cfg.Audience
 
-		if len(scopes) == 0 || len(audienceValue) == 0 {
+		if len(scopes) == 0 || cfg.UseAudienceFromAdmin {
 			publicClientConfig, err := authClient.GetPublicClientConfig(ctx, &service.PublicClientAuthConfigRequest{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch client metadata. Error: %v", err)
@@ -63,9 +63,7 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 				scopes = publicClientConfig.Scopes
 			}
 			// Update audience from publicClientConfig
-			if len(audienceValue) == 0 {
-				audienceValue = publicClientConfig.Audience
-			}
+			audienceValue = publicClientConfig.Audience
 		}
 
 		tokenProvider, err = NewClientCredentialsTokenSourceProvider(ctx, cfg, scopes, tokenURL, audienceValue)

--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -63,7 +63,9 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 				scopes = publicClientConfig.Scopes
 			}
 			// Update audience from publicClientConfig
-			audienceValue = publicClientConfig.Audience
+			if cfg.UseAudienceFromAdmin {
+				audienceValue = publicClientConfig.Audience
+			}
 		}
 
 		tokenProvider, err = NewClientCredentialsTokenSourceProvider(ctx, cfg, scopes, tokenURL, audienceValue)

--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	audience = "audience"
+	audienceKey = "audience"
 )
 
 // TokenSourceProvider defines the interface needed to provide a TokenSource that is used to
@@ -63,7 +63,7 @@ func NewTokenSourceProvider(ctx context.Context, cfg *Config, tokenCache cache.T
 		if len(audienceValue) == 0 {
 			audienceValue = clientMetadata.Audience
 		}
-		
+
 		tokenProvider, err = NewClientCredentialsTokenSourceProvider(ctx, cfg, scopes, tokenURL, audienceValue)
 		if err != nil {
 			return nil, err
@@ -176,7 +176,7 @@ func NewClientCredentialsTokenSourceProvider(ctx context.Context, cfg *Config, s
 	}
 	endpointParams := url.Values{}
 	if len(audience) > 0 {
-		endpointParams = url.Values{audience: {audience}}
+		endpointParams = url.Values{audienceKey: {audience}}
 	}
 	secret = strings.TrimSpace(secret)
 	return ClientCredentialsTokenSourceProvider{

--- a/clients/go/admin/token_source_test.go
+++ b/clients/go/admin/token_source_test.go
@@ -2,10 +2,16 @@ package admin
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"golang.org/x/oauth2"
+
+	tokenCacheMocks "github.com/flyteorg/flyteidl/clients/go/admin/cache/mocks"
+	adminMocks "github.com/flyteorg/flyteidl/clients/go/admin/mocks"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
 )
 
 type DummyTestTokenSource struct {
@@ -24,4 +30,43 @@ func TestNewTokenSource(t *testing.T) {
 	metadata, err := flyteTokenSource.GetRequestMetadata(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "Bearer abc", metadata["test"])
+}
+
+func TestNewTokenSourceProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("audience from client config", func(t *testing.T) {
+		cfg := GetConfig(ctx)
+		tokenCache := &tokenCacheMocks.TokenCache{}
+		metadataClient := &adminMocks.AuthMetadataServiceClient{}
+		metadataClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{}, nil)
+		metadataClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{}, nil)
+		cfg.AuthType = AuthTypeClientSecret
+		cfg.Audience = "aud"
+		cfg.Scopes = []string{"all"}
+		flyteTokenSource, err := NewTokenSourceProvider(ctx, cfg, tokenCache, metadataClient)
+		assert.NoError(t, err)
+		assert.NotNil(t, flyteTokenSource)
+		clientCredSourceProvider, ok := flyteTokenSource.(ClientCredentialsTokenSourceProvider)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"all"}, clientCredSourceProvider.ccConfig.Scopes)
+		assert.Equal(t, url.Values{audienceKey: {"aud"}}, clientCredSourceProvider.ccConfig.EndpointParams)
+	})
+	t.Run("audience from public client response", func(t *testing.T) {
+		cfg := GetConfig(ctx)
+		tokenCache := &tokenCacheMocks.TokenCache{}
+		metadataClient := &adminMocks.AuthMetadataServiceClient{}
+		metadataClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{}, nil)
+		metadataClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&service.PublicClientAuthConfigResponse{Audience: "aud", Scopes: []string{"all"}}, nil)
+		cfg.AuthType = AuthTypeClientSecret
+		cfg.Audience = ""
+		cfg.Scopes = []string{}
+		flyteTokenSource, err := NewTokenSourceProvider(ctx, cfg, tokenCache, metadataClient)
+		assert.NoError(t, err)
+		assert.NotNil(t, flyteTokenSource)
+		clientCredSourceProvider, ok := flyteTokenSource.(ClientCredentialsTokenSourceProvider)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"all"}, clientCredSourceProvider.ccConfig.Scopes)
+		assert.Equal(t, url.Values{audienceKey: {"aud"}}, clientCredSourceProvider.ccConfig.EndpointParams)
+	})
 }

--- a/clients/go/admin/token_source_test.go
+++ b/clients/go/admin/token_source_test.go
@@ -38,44 +38,45 @@ func TestNewTokenSourceProvider(t *testing.T) {
 		name                 string
 		audienceCfg          string
 		scopesCfg            []string
+		useAudienceFromAdmin bool
 		clientConfigResponse service.PublicClientAuthConfigResponse
 		expectedAudience     string
 		expectedScopes       []string
 	}{
 		{
 			name:                 "audience from client config",
-			audienceCfg:          "aud",
+			audienceCfg:          "clientConfiguredAud",
 			scopesCfg:            []string{"all"},
 			clientConfigResponse: service.PublicClientAuthConfigResponse{},
-			expectedAudience:     "aud",
+			expectedAudience:     "clientConfiguredAud",
 			expectedScopes:       []string{"all"},
 		},
 		{
 			name:                 "audience from public client response",
-			audienceCfg:          "",
-			scopesCfg:            []string{},
-			clientConfigResponse: service.PublicClientAuthConfigResponse{Audience: "aud", Scopes: []string{"all"}},
-			expectedAudience:     "aud",
+			audienceCfg:          "clientConfiguredAud",
+			useAudienceFromAdmin: true,
+			scopesCfg:            []string{"all"},
+			clientConfigResponse: service.PublicClientAuthConfigResponse{Audience: "AdminConfiguredAud", Scopes: []string{}},
+			expectedAudience:     "AdminConfiguredAud",
 			expectedScopes:       []string{"all"},
 		},
 	}
 	for _, test := range tests {
-		t.Run("audience from client config", func(t *testing.T) {
-			cfg := GetConfig(ctx)
-			tokenCache := &tokenCacheMocks.TokenCache{}
-			metadataClient := &adminMocks.AuthMetadataServiceClient{}
-			metadataClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{}, nil)
-			metadataClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&test.clientConfigResponse, nil)
-			cfg.AuthType = AuthTypeClientSecret
-			cfg.Audience = test.audienceCfg
-			cfg.Scopes = test.scopesCfg
-			flyteTokenSource, err := NewTokenSourceProvider(ctx, cfg, tokenCache, metadataClient)
-			assert.NoError(t, err)
-			assert.NotNil(t, flyteTokenSource)
-			clientCredSourceProvider, ok := flyteTokenSource.(ClientCredentialsTokenSourceProvider)
-			assert.True(t, ok)
-			assert.Equal(t, test.expectedScopes, clientCredSourceProvider.ccConfig.Scopes)
-			assert.Equal(t, url.Values{audienceKey: {test.expectedAudience}}, clientCredSourceProvider.ccConfig.EndpointParams)
-		})
+		cfg := GetConfig(ctx)
+		tokenCache := &tokenCacheMocks.TokenCache{}
+		metadataClient := &adminMocks.AuthMetadataServiceClient{}
+		metadataClient.OnGetOAuth2MetadataMatch(mock.Anything, mock.Anything).Return(&service.OAuth2MetadataResponse{}, nil)
+		metadataClient.OnGetPublicClientConfigMatch(mock.Anything, mock.Anything).Return(&test.clientConfigResponse, nil)
+		cfg.AuthType = AuthTypeClientSecret
+		cfg.Audience = test.audienceCfg
+		cfg.Scopes = test.scopesCfg
+		cfg.UseAudienceFromAdmin = test.useAudienceFromAdmin
+		flyteTokenSource, err := NewTokenSourceProvider(ctx, cfg, tokenCache, metadataClient)
+		assert.NoError(t, err)
+		assert.NotNil(t, flyteTokenSource)
+		clientCredSourceProvider, ok := flyteTokenSource.(ClientCredentialsTokenSourceProvider)
+		assert.True(t, ok)
+		assert.Equal(t, test.expectedScopes, clientCredSourceProvider.ccConfig.Scopes)
+		assert.Equal(t, url.Values{audienceKey: {test.expectedAudience}}, clientCredSourceProvider.ccConfig.EndpointParams)
 	}
 }


### PR DESCRIPTION
Signed-off-by: pmahindrakar-oss <prafulla.mahindrakar@gmail.com>

# TL;DR
Most Authorization server provide a way to use default audience which can be used to request auth tokens which is what flyte relied on before this PR.

The current PR allows to send a configurable audience field when requesting auth token from the authorization server.

Follow up PR to return audience also from PublicClientConfig endpoint of flyteadmin

https://github.com/flyteorg/flyteadmin/pull/485

If client config contains the audience field then that would be used 
Though if the override to useAudienceFromAdmin is set then whatever audience is set in admin would be used

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2959

## Follow-up issue
_NA_

