### PR TITLE
Dockerize buf call

### DIFF
--- a/generate_protos.sh
+++ b/generate_protos.sh
@@ -29,10 +29,7 @@ do
 done
 
 # Buf migration
-# TODO: fix stub generation via docker image. The trick of forcing the current user as a user in
-# the container (used extensively in this file) does not work.
-# docker run --volume "$(pwd):/workspace" --workdir /workspace bufbuild/buf generate
-buf generate
+docker run -u $(id -u):$(id -g) -e "BUF_CACHE_DIR=/tmp/cache" --volume "$(pwd):/workspace" --workdir /workspace bufbuild/buf generate
 
 # Unfortunately the python protoc plugin does not add __init__.py files to the generated code
 # (as described in https://github.com/protocolbuffers/protobuf/issues/881). One of the


### PR DESCRIPTION
# TL;DR
Dockerizing the `buf` call so users do not need to manually install `buf` to generate protos. The PR uses the existing approach of setting the user id but requires manually setting the buf cache directory. If not set it will default to the root users home (ie. `/.cache`) which the caller likely does not have permissions to access. Therefore, we set it to `/tmp/cache` which should be globally accessible.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3139

## Follow-up issue
_NA_
