### PR TITLE
Adding support for structured dataset

### DIFF
--- a/clients/go/coreutils/extract_literal.go
+++ b/clients/go/coreutils/extract_literal.go
@@ -60,6 +60,8 @@ func ExtractFromLiteral(literal *core.Literal) (interface{}, error) {
 			return scalarValue.Schema.Uri, nil
 		case *core.Scalar_Generic:
 			return scalarValue.Generic, nil
+		case *core.Scalar_StructuredDataset:
+			return scalarValue.StructuredDataset.Uri, nil
 		default:
 			return nil, fmt.Errorf("unsupported literal scalar type %T", scalarValue)
 		}

--- a/clients/go/coreutils/extract_literal_test.go
+++ b/clients/go/coreutils/extract_literal_test.go
@@ -176,4 +176,27 @@ func TestFetchLiteral(t *testing.T) {
 			assert.Equal(t, val.Kind, extractedStructValue.Fields[key].Kind)
 		}
 	})
+
+	t.Run("Structured dataset", func(t *testing.T) {
+		literalVal := "s3://blah/blah/blah"
+		var dataSetColumns []*core.StructuredDatasetType_DatasetColumn
+		dataSetColumns = append(dataSetColumns, &core.StructuredDatasetType_DatasetColumn{
+			Name: "Price",
+			LiteralType: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_FLOAT,
+				},
+			},
+		})
+		var literalType = &core.LiteralType{Type: &core.LiteralType_StructuredDatasetType{StructuredDatasetType: &core.StructuredDatasetType{
+			Columns: dataSetColumns,
+			Format:  "testFormat",
+		}}}
+
+		lit, err := MakeLiteralForType(literalType, literalVal)
+		assert.NoError(t, err)
+		extractedLiteralVal, err := ExtractFromLiteral(lit)
+		assert.NoError(t, err)
+		assert.Equal(t, literalVal, extractedLiteralVal)
+	})
 }

--- a/clients/go/coreutils/literals.go
+++ b/clients/go/coreutils/literals.go
@@ -436,6 +436,26 @@ func MakeLiteralForSchema(path storage.DataReference, columns []*core.SchemaType
 	}
 }
 
+func MakeLiteralForStructuredDataSet(path storage.DataReference, columns []*core.StructuredDatasetType_DatasetColumn, format string) *core.Literal {
+	return &core.Literal{
+		Value: &core.Literal_Scalar{
+			Scalar: &core.Scalar{
+				Value: &core.Scalar_StructuredDataset{
+					StructuredDataset: &core.StructuredDataset{
+						Uri: path.String(),
+						Metadata: &core.StructuredDatasetMetadata{
+							StructuredDatasetType: &core.StructuredDatasetType{
+								Columns: columns,
+								Format:  format,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func MakeLiteralForBlob(path storage.DataReference, isDir bool, format string) *core.Literal {
 	dim := core.BlobType_SINGLE
 	if isDir {
@@ -537,6 +557,9 @@ func MakeLiteralForType(t *core.LiteralType, v interface{}) (*core.Literal, erro
 
 	case *core.LiteralType_Schema:
 		lv := MakeLiteralForSchema(storage.DataReference(fmt.Sprintf("%v", v)), newT.Schema.Columns)
+		return lv, nil
+	case *core.LiteralType_StructuredDatasetType:
+		lv := MakeLiteralForStructuredDataSet(storage.DataReference(fmt.Sprintf("%v", v)), newT.StructuredDatasetType.Columns, newT.StructuredDatasetType.Format)
 		return lv, nil
 
 	case *core.LiteralType_EnumType:

--- a/clients/go/coreutils/literals_test.go
+++ b/clients/go/coreutils/literals_test.go
@@ -675,4 +675,44 @@ func TestMakeLiteralForType(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "", l.GetScalar().GetPrimitive().GetStringValue())
 	})
+
+	t.Run("Structured Data Set", func(t *testing.T) {
+		var dataSetColumns []*core.StructuredDatasetType_DatasetColumn
+		dataSetColumns = append(dataSetColumns, &core.StructuredDatasetType_DatasetColumn{
+			Name: "Price",
+			LiteralType: &core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_FLOAT,
+				},
+			},
+		})
+		var literalType = &core.LiteralType{Type: &core.LiteralType_StructuredDatasetType{StructuredDatasetType: &core.StructuredDatasetType{
+			Columns: dataSetColumns,
+			Format:  "testFormat",
+		}}}
+
+		expectedLV := &core.Literal{Value: &core.Literal_Scalar{Scalar: &core.Scalar{
+			Value: &core.Scalar_StructuredDataset{
+				StructuredDataset: &core.StructuredDataset{
+					Uri: "s3://blah/blah/blah",
+					Metadata: &core.StructuredDatasetMetadata{
+						StructuredDatasetType: &core.StructuredDatasetType{
+							Columns: dataSetColumns,
+							Format:  "testFormat",
+						},
+					},
+				},
+			},
+		}}}
+		lv, err := MakeLiteralForType(literalType, "s3://blah/blah/blah")
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedLV, lv)
+
+		expectedVal, err := ExtractFromLiteral(expectedLV)
+		assert.NoError(t, err)
+		actualVal, err := ExtractFromLiteral(lv)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedVal, actualVal)
+	})
 }


### PR DESCRIPTION
# TL;DR

Adds support for structured data set for flytectl

Followup PR in  flytectl to dumps the output which were missing in details flag.

Eg o/p for execution with structured dataset. It dumps the URI currently for the stored o/p.


```
 flytectl get executions -p flytesnacks -d development f12ce5ce3aae045378c1  --details 
TABLE format is not supported on detailed view and defaults to tree view. Choose either json/yaml

└── start-node - SUCCEEDED - 2023-02-21 19:20:26.545951047 +0000 UTC - 2023-02-21 19:20:26.545951047 +0000 UTC
│   ├── Outputs :
│       └── a: 2
└── n0 - SUCCEEDED - 2023-02-21 19:20:26.777756742 +0000 UTC - 2023-02-21 19:20:41.033027942 +0000 UTC
│   ├── Attempt :0
│   │   ├── Task - SUCCEEDED - 2023-02-21 19:20:27.069960835 +0000 UTC - 2023-02-21 19:20:40.827311935 +0000 UTC
│   │   ├── Task Type - python-task
│   │   ├── Reason - [ContainersNotReady|ContainerCreating]: containers with unready status: [f12ce5ce3aae045378c1-n0-0]|
│   │   ├── Metadata
│   │   │   ├── Generated Name : f12ce5ce3aae045378c1-n0-0
│   │   │   ├── Plugin Identifier : container
│   │   │   ├── External Resources
│   │   │   ├── Resource Pool Info
│   │   ├── Logs :
│   │       └── Name :Cloudwatch Logs (User)
│   │       └── URI :https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fopta-oc-canary$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.f12ce5ce3aae045378c1-n0-0_flytesnacks-development_f12ce5ce3aae045378c1-n0-0
│   ├── Outputs :
│       └── o0: s3://union-oc-canary-playground/7y/f12ce5ce3aae045378c1-n0-0/2a1d85ef4a87410f5a04ce889e876776
└── n1 - SUCCEEDED - 2023-02-21 19:20:41.420976535 +0000 UTC - 2023-02-21 19:20:57.090747824 +0000 UTC
│   ├── Attempt :0
│   │   ├── Task - SUCCEEDED - 2023-02-21 19:20:41.720309792 +0000 UTC - 2023-02-21 19:20:56.914747315 +0000 UTC
│   │   ├── Task Type - python-task
│   │   ├── Reason - [ContainersNotReady|ContainerCreating]: containers with unready status: [f12ce5ce3aae045378c1-n1-0]|
│   │   ├── Metadata
│   │   │   ├── Generated Name : f12ce5ce3aae045378c1-n1-0
│   │   │   ├── Plugin Identifier : container
│   │   │   ├── External Resources
│   │   │   ├── Resource Pool Info
│   │   ├── Logs :
│   │       └── Name :Cloudwatch Logs (User)
│   │       └── URI :https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fopta-oc-canary$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.f12ce5ce3aae045378c1-n1-0_flytesnacks-development_f12ce5ce3aae045378c1-n1-0
│   ├── Outputs :
│       └── o0: s3://union-oc-canary-playground/g9/f12ce5ce3aae045378c1-n1-0/e340ecf4db7d64e3a539665cb7648047
└── n2 - SUCCEEDED - 2023-02-21 19:20:57.318835153 +0000 UTC - 2023-02-21 19:21:11.021544907 +0000 UTC
│   ├── Attempt :0
│   │   ├── Task - SUCCEEDED - 2023-02-21 19:20:57.56183156 +0000 UTC - 2023-02-21 19:21:10.828786539 +0000 UTC
│   │   ├── Task Type - python-task
│   │   ├── Reason - [ContainersNotReady|ContainerCreating]: containers with unready status: [f12ce5ce3aae045378c1-n2-0]|
│   │   ├── Metadata
│   │   │   ├── Generated Name : f12ce5ce3aae045378c1-n2-0
│   │   │   ├── Plugin Identifier : container
│   │   │   ├── External Resources
│   │   │   ├── Resource Pool Info
│   │   ├── Logs :
│   │       └── Name :Cloudwatch Logs (User)
│   │       └── URI :https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fopta-oc-canary$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.f12ce5ce3aae045378c1-n2-0_flytesnacks-development_f12ce5ce3aae045378c1-n2-0
│   ├── Outputs :
│       └── o0: s3://union-oc-canary-playground/o4/f12ce5ce3aae045378c1-n2-0/0d1195b0dbded5310076263af1f96315
└── end-node - SUCCEEDED - 2023-02-21 19:21:11.401510279 +0000 UTC - 2023-02-21 19:21:11.541818271 +0000 UTC
```

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/2757

## Follow-up issue
