### PR TITLE
Remove misleading token refresh logic from client credentials token source provider

### DIFF
--- a/clients/go/admin/token_source_provider.go
+++ b/clients/go/admin/token_source_provider.go
@@ -8,11 +8,9 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/flyteorg/flyteidl/clients/go/admin/cache"
 	"github.com/flyteorg/flyteidl/clients/go/admin/deviceflow"
@@ -167,9 +165,8 @@ func GetPKCEAuthTokenSource(ctx context.Context, pkceTokenOrchestrator pkce.Toke
 }
 
 type ClientCredentialsTokenSourceProvider struct {
-	ccConfig           clientcredentials.Config
-	tokenRefreshWindow time.Duration
-	tokenCache         cache.TokenCache
+	ccConfig   clientcredentials.Config
+	tokenCache cache.TokenCache
 }
 
 func NewClientCredentialsTokenSourceProvider(ctx context.Context, cfg *Config, scopes []string, tokenURL string,
@@ -201,93 +198,45 @@ func NewClientCredentialsTokenSourceProvider(ctx context.Context, cfg *Config, s
 			Scopes:         scopes,
 			EndpointParams: endpointParams,
 		},
-		tokenRefreshWindow: cfg.TokenRefreshWindow.Duration,
-		tokenCache:         tokenCache}, nil
+		tokenCache: tokenCache}, nil
 }
 
 func (p ClientCredentialsTokenSourceProvider) GetTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
-	if p.tokenRefreshWindow > 0 {
-		source := p.ccConfig.TokenSource(ctx)
-		refreshTime := time.Time{}
-		if token, err := p.tokenCache.GetToken(); err == nil {
-			refreshTime = token.Expiry.Add(-getRandomDuration(p.tokenRefreshWindow))
-			logger.Infof(ctx, "initializing with cached token, expiry: %v, refreshTime: %v", token.Expiry, refreshTime)
-		}
-		return &customTokenSource{
-			ctx:                ctx,
-			new:                source,
-			mu:                 sync.Mutex{},
-			tokenRefreshWindow: p.tokenRefreshWindow,
-			tokenCache:         p.tokenCache,
-			refreshTime:        refreshTime,
-		}, nil
-	}
-	return p.ccConfig.TokenSource(ctx), nil
+	return &customTokenSource{
+		ctx:        ctx,
+		new:        p.ccConfig.TokenSource(ctx),
+		mu:         sync.Mutex{},
+		tokenCache: p.tokenCache,
+	}, nil
 }
 
 type customTokenSource struct {
-	ctx                context.Context
-	new                oauth2.TokenSource
-	tokenRefreshWindow time.Duration
-	mu                 sync.Mutex // guards everything else
-	refreshTime        time.Time
-	failedToRefresh    bool
-	tokenCache         cache.TokenCache
-}
-
-// fetchTokenFromCache returns the cached token if available, and a bool indicating if we should try to refresh it.
-// This function is not thread safe and should be called with the lock held.
-func (s *customTokenSource) fetchTokenFromCache() (*oauth2.Token, bool) {
-	token, err := s.tokenCache.GetToken()
-	if err != nil {
-		logger.Infof(s.ctx, "no token found in cache")
-		return nil, false
-	}
-	if !token.Valid() {
-		logger.Infof(s.ctx, "cached token invalid")
-		return nil, false
-	}
-	if time.Now().After(s.refreshTime) && !s.failedToRefresh {
-		logger.Infof(s.ctx, "cached token refresh window exceeded, refreshTime: %v", s.refreshTime)
-		return token, true
-	}
-	return token, false
+	ctx        context.Context
+	mu         sync.Mutex // guards everything else
+	new        oauth2.TokenSource
+	tokenCache cache.TokenCache
 }
 
 func (s *customTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cachedToken, needsRefresh := s.fetchTokenFromCache()
-	if cachedToken != nil && !needsRefresh {
-		return cachedToken, nil
+	if token, err := s.tokenCache.GetToken(); err == nil && token.Valid() {
+		return token, nil
 	}
 
 	token, err := s.new.Token()
 	if err != nil {
-		if needsRefresh {
-			logger.Warnf(s.ctx, "failed to refresh token, using last cached token until expired")
-			s.failedToRefresh = true
-			return cachedToken, nil
-		}
-		logger.Errorf(s.ctx, "failed to refresh token")
-		return nil, err
+		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
+	logger.Infof(s.ctx, "retrieved token with expiry %v", token.Expiry)
+
 	err = s.tokenCache.SaveToken(token)
 	if err != nil {
-		logger.Warnf(s.ctx, "failed to cache token, using anyway")
+		logger.Warnf(s.ctx, "failed to cache token")
 	}
-	s.failedToRefresh = false
-	s.refreshTime = token.Expiry.Add(-getRandomDuration(s.tokenRefreshWindow))
-	logger.Infof(s.ctx, "refreshed token, expiry: %v, refreshTime: %v", token.Expiry, s.refreshTime)
-	return token, nil
-}
 
-// Get random duration between 0 and maxDuration
-func getRandomDuration(maxDuration time.Duration) time.Duration {
-	// d is 1.0 to 2.0 times maxDuration
-	d := wait.Jitter(maxDuration, 1)
-	return d - maxDuration
+	return token, nil
 }
 
 type DeviceFlowTokenSourceProvider struct {


### PR DESCRIPTION
# TL;DR
Removes unnecessary refresh logic from `ClientCredentialsTokenSourceProvider` and `customTokenSource`, as it's not supported by underlying client credentials token source.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Previously `customTokenSource` attempted to refresh near-expiration tokens; however, the underlying [client credentials token source](https://cs.opensource.google/go/x/oauth2/+/refs/tags/v0.6.0:clientcredentials/clientcredentials.go;l=70-81) would always return the existing token, if valid.

This change drops all of the refresh logic but maintains the token cache recently added to allow tokens to be reused across token providers, consistent with the interface used for [other token providers](https://github.com/flyteorg/flyteidl/blob/bdb76306558b64645f095bc34b32ac487222fc3f/clients/go/admin/token_source_provider.go#L41). In effect the underlying client credentials token source cache is not used (queries should always require a new token).

## Tracking Issue
NA

## Follow-up issue
NA