### PR TITLE
Retract 1.4.x - #minor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,3 +82,9 @@ require (
 	k8s.io/client-go v0.0.0-20210217172142-7279fc64d847 // indirect
 	k8s.io/klog/v2 v2.5.0 // indirect
 )
+
+// These 2 versions were wrongly published. 
+retract (
+	v1.4.0
+	v1.4.2
+)


### PR DESCRIPTION
# TL;DR
Retract 1.4.x versions and bump latest tag to 1.5.0

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://github.com/flyteorg/flyteidl/pull/339 caused some issues in flytekit (due to [this](https://github.com/flyteorg/flytekit/blob/master/setup.py#L32) version check). We ended up deleting the release tags, but didn't retract the flyteidl go module versions. This PR adds a [`retract` statement](https://go.dev/ref/mod#go-mod-file-retract) to remove those 2 bad versions from pkg.go.dev.

The plan is to re-create the 1.4.0 release tag temporarily prior to merging this PR, so that we generate a clean 1.5.0 release.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
