### PR TITLE
Correct comment for array job max parallelism

### DIFF
--- a/gen/pb-go/flyteidl/plugins/array_job.pb.go
+++ b/gen/pb-go/flyteidl/plugins/array_job.pb.go
@@ -23,7 +23,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 // Describes a job that can process independent pieces of data concurrently. Multiple copies of the runnable component
 // will be executed concurrently.
 type ArrayJob struct {
-	// Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+	// Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
 	// optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
 	// running instances might be more. This has to be a positive number if assigned. Default value is size.
 	Parallelism int64 `protobuf:"varint,1,opt,name=parallelism,proto3" json:"parallelism,omitempty"`

--- a/gen/pb-java/flyteidl/plugins/ArrayJobOuterClass.java
+++ b/gen/pb-java/flyteidl/plugins/ArrayJobOuterClass.java
@@ -20,7 +20,7 @@ public final class ArrayJobOuterClass {
 
     /**
      * <pre>
-     * Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+     * Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
      * optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
      * running instances might be more. This has to be a positive number if assigned. Default value is size.
      * </pre>
@@ -201,7 +201,7 @@ public final class ArrayJobOuterClass {
     private long parallelism_;
     /**
      * <pre>
-     * Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+     * Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
      * optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
      * running instances might be more. This has to be a positive number if assigned. Default value is size.
      * </pre>
@@ -672,7 +672,7 @@ public final class ArrayJobOuterClass {
       private long parallelism_ ;
       /**
        * <pre>
-       * Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+       * Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
        * optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
        * running instances might be more. This has to be a positive number if assigned. Default value is size.
        * </pre>
@@ -684,7 +684,7 @@ public final class ArrayJobOuterClass {
       }
       /**
        * <pre>
-       * Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+       * Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
        * optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
        * running instances might be more. This has to be a positive number if assigned. Default value is size.
        * </pre>
@@ -699,7 +699,7 @@ public final class ArrayJobOuterClass {
       }
       /**
        * <pre>
-       * Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+       * Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
        * optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
        * running instances might be more. This has to be a positive number if assigned. Default value is size.
        * </pre>

--- a/gen/pb_rust/flyteidl.plugins.rs
+++ b/gen/pb_rust/flyteidl.plugins.rs
@@ -4,7 +4,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrayJob {
-    /// Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+    /// Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
     /// optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
     /// running instances might be more. This has to be a positive number if assigned. Default value is size.
     #[prost(int64, tag="1")]

--- a/protos/flyteidl/plugins/array_job.proto
+++ b/protos/flyteidl/plugins/array_job.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins";
 // Describes a job that can process independent pieces of data concurrently. Multiple copies of the runnable component
 // will be executed concurrently.
 message ArrayJob {
-    // Defines the minimum number of instances to bring up concurrently at any given point. Note that this is an
+    // Defines the maximum number of instances to bring up concurrently at any given point. Note that this is an
     // optimistic restriction and that, due to network partitioning or other failures, the actual number of currently
     // running instances might be more. This has to be a positive number if assigned. Default value is size.
     int64 parallelism = 1;


### PR DESCRIPTION
## TL;DR
Update comment to indicate array job parallelism indicates max not min

Currently, the comment
https://github.com/flyteorg/flyteidl/blob/b0c083121c310f088cc41fa111ba318bff20c83e/protos/flyteidl/plugins/array_job.proto#L13

implies that the parallelism field for array jobs is a min

however plugins code reads the field as a max:
https://github.com/flyteorg/flyteplugins/blob/c528bb88937b4732c9cb5537ed8ea6943ff4fb56/go/tasks/plugins/array/k8s/management.go#L145

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Docs

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
N/A

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3933

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
